### PR TITLE
Allow for this session button added, current session model displayed, waiting for user visuals and local install scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,308 @@
+# Contributing to VsAgentic
+
+## Prerequisites
+
+| Requirement                             | Notes                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Visual Studio 2026** (18.x)           | Install the **Visual Studio extension development** workload — it supplies the VSSDK build tools, `CreateExpInstance.exe`, and the Experimental Instance machinery.                                                                                                                                           |
+| **.NET Framework 4.7.2 targeting pack** | Every project targets `net472`. Included with the extension development workload.                                                                                                                                                                                                                             |
+| **Node.js 18+**                         | Only needed to install the Claude CLI.                                                                                                                                                                                                                                                                        |
+| **Claude Code CLI, logged in**          | In the future the API won't be supported, and only subscrptions.<br>`npm install -g @anthropic-ai/claude-code` then `claude login`. The extension shells out to this binary and uses **subscription auth** — an `ANTHROPIC_API_KEY` env var is explicitly cleared before spawning, so API keys will not work. |
+| **A Claude Pro or Max subscription**    | Required by the CLI.                                                                                                                                                                                                                                                                                          |
+
+Verify the CLI works standalone before debugging the extension — most "nothing happens" reports trace back to an unauthenticated CLI:
+
+```powershell
+claude -p "hello"
+```
+
+## Build
+
+```powershell
+dotnet restore src/VsAgentic.slnx
+dotnet build src/VsAgentic.slnx -c Release -v minimal
+```
+
+The VSIX lands in `src/VsAgentic.VSExtension/bin/<config>/`. A `Debug` build is what you want for local iteration.
+
+`VsAgentic.Services` has a build-time dependency on the MCP helper: the `EmbedMcpHelper` target zips `VsAgentic.Services.McpPermissionServer/bin/<config>/net472/` into an embedded resource. If you see
+
+```
+MCP helper exe not found at ... Build VsAgentic.Services.McpPermissionServer first.
+```
+
+build the solution (not just one project) — the helper is wired as a `ProjectReference` with `ReferenceOutputAssembly=false` purely to force that ordering.
+
+## Running it in VS 2026
+
+**F5 is the normal way to debug on this solution.** It runs the whole solution and runs all the components end to end.
+
+The repo also contains two smaller applications — `VsAgentic.Desktop` and `VsAgentic.Console` — that reuse the lower layers without Visual Studio. They exist to give a faster loop than a full Experimental Instance launch, but **both are not ready for separate running** (see below).
+
+### Debugging in the VS Experimental Instance
+
+With **VsAgentic.VSExtension** as the startup project and press **F5**. VS builds the VSIX, deploys it into a sandboxed instance (`devenv.exe /rootsuffix Exp`), and attaches the debugger.
+
+> Deployment depends on the `DeployExtension` property set in `VsAgentic.VSExtension.csproj` — **not** on the `<Deploy Solution="Debug|*" />` entry in `VsAgentic.slnx`, which only controls the Configuration Manager checkbox. `Microsoft.VisualStudio.Extensibility.Build.targets` defaults `DeployExtension` to `false` and is imported after the VSSDK targets that default it to `true`, so a hybrid VSSDK + VisualStudio.Extensibility extension gets no deployment unless the project overrides it. The property is deliberately scoped to full-framework MSBuild, because the VSSDK targets hard-error on `dotnet build`. If you ever need to confirm what it evaluates to:
+> 
+> ```powershell
+> & "C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\MSBuild.exe" `
+>     src\VsAgentic.VSExtension\VsAgentic.VSExtension.csproj -getProperty:DeployExtension -nologo
+> ```
+
+VS terms the sandboxed version as the "Experimental Instance", and creates a full replica VS install that is isolated from the standard install. When using note:
+
+1. Open any solution — VsAgentic scopes the CLI's working directory to the solution directory, and with no solution open it falls back to your user profile.
+2. **View → Other Windows → VsAgentic** opens a chat window. The **VsAgentic Sessions** panel docks next to Solution Explorer.
+3. Settings live under **Tools → Options → VsAgentic → General** (CLI path, permission mode, session retention days).
+
+This is the only way to exercise tool windows, the VS options page, solution-switch handling, file-link navigation into the editor, and the assembly-resolve bootstrap — nothing below `VsAgentic.VSExtension` can stand in for it.
+
+**Resetting the Experimental Instance** — do this when the sandbox gets into a bad state (duplicate extensions, a stale build that won't go away):
+
+```powershell
+& "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VSSDK\VisualStudioIntegration\Tools\Bin\CreateExpInstance.exe" /Reset /VSInstance=18.0 /RootSuffix=Exp
+```
+
+Adjust the edition in the path to match your install. If an old build keeps loading, also delete stale VsAgentic folders under the Experimental Instance's `Extensions\` directory — check each folder's `extension.vsixmanifest` to identify the version.
+
+**Where the Experimental Instance lives:** `%LocalAppData%\Microsoft\VisualStudio\18.0_<id>Exp\`, with the extension under `Extensions\<Publisher>\<DisplayName>\<Version>\`. A near-empty `...\VisualStudio\exp\` folder also exists and holds only settings — it is not the instance root, so don't be misled by it.
+
+#### Setting breakpoints not working
+
+In VS 2026 version 18.7.4 - setting breakpoints basically confuses the IDE and most of the time both the launching instance and experimental instance just hang.  
+
+#### Problems with versioning in Experimental Instance
+
+Sometimes it mighe be unclear if the changes have deployed to the experimental instance, so to prove whether the extension deployed at all:
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\Microsoft\VisualStudio" -Recurse -Filter "extension.vsixmanifest" -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -notmatch '\\Designer\\Cache\\' } |
+    ForEach-Object { $x=[xml](Get-Content $_.FullName)
+        if ($x.PackageManifest.Metadata.Identity.Id -like '*VsAgentic*') {
+            "v{0}  {1}" -f $x.PackageManifest.Metadata.Identity.Version, $_.DirectoryName } }
+```
+
+No hits means it was never installed — a deployment problem, not a code problem. The `Designer\Cache\` exclusion matters: the XAML designer caches copies of the extension assemblies there, and those paths are **not** deployments.
+
+A correct deployment contains `VsAgentic.VSExtension.pkgdef` *and* `.vsextension\extension.json`. These feed two independent registration systems, which is worth knowing because they fail independently:
+
+| Deployed file                  | Registers                                                                                  | Symptom if only this one works                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `VsAgentic.VSExtension.pkgdef` | The VSSDK package, Tools → Options page, tool window types                                 | Settings appear under Tools → Options, but **no menu entry** to open a chat window |
+| `.vsextension\extension.json`  | The VisualStudio.Extensibility command `OpenChatSessionCommand` under View → Other Windows | The menu entry appears but the package never loads                                 |
+
+There is no `.vsct` in this repo — the View → Other Windows entry comes *only* from `extension.json`. So "Options page present, no window" points squarely at the VisualStudio.Extensibility side, not at the package.
+
+**Note:** the absence of `%LocalAppData%\VsAgentic\resolver.log` does *not* prove the extension failed to load. `AssemblyResolveBootstrap` only writes that file when the `AssemblyResolve` fallback actually fires; if the default binder resolves everything, the file is never created. Use the deployment check above, or `%AppData%\VsAgentic\logs\vsagentic-<date>.log`, to tell whether the package initialized.
+
+## The standalone apps
+
+`VsAgentic.Desktop` and `VsAgentic.Console` are not part of the extension, and aren't configured to run as part of this solution. They are small applications that call the same composition root, `AddVsAgenticServices`, so they can drive the CLI without Visual Studio in the picture:
+
+|                         | Layers it exercises                   | What it is for                                                                                                                                                                                                                                                                                             |
+| ----------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`VsAgentic.Console`** | `VsAgentic.Services` only             | The CLI conversation loop with no UI at all — stream-json protocol, process host, the MCP → pipe → broker permission chain. Permission prompts become a `y/N` on stdin and `AskUserQuestion` a numbered list, so you can watch the plumbing directly. Tool steps print inline via `ConsoleOutputListener`. |
+| **`VsAgentic.Desktop`** | `VsAgentic.Services` + `VsAgentic.UI` | The same `ChatSessionViewModel` and `ChatWebView` the extension uses, in a plain WPF window — WebView2 rendering, markdown output, banner behaviour.                                                                                                                                                       |
+
+Both take the working directory as `args[0]`. The appeal is the loop time: seconds to restart versus a full Experimental Instance launch, and no Exp settings hive to configure. Neither can tell you anything about tool windows, the options page, solution switching, editor navigation, or the assembly-resolve bootstrap — those only exist above this layer, in `VsAgentic.VSExtension`.
+
+**Neither builds today.** Both are absent from `VsAgentic.slnx`, so CI and every normal build skip them, and they have drifted since v3.0.15 (`git log -- src/VsAgentic.Desktop src/VsAgentic.Console`) while the extension is on 3.4.x.
+
+*Both* fail at restore, before any compilation:
+
+```
+error NU1107: Version conflict detected for System.Text.Json.
+  VsAgentic.Console -> Microsoft.Extensions.Hosting 10.0.5 -> ... -> System.Text.Json (>= 10.0.5)
+  VsAgentic.Console -> VsAgentic.Services -> System.Text.Json (= 10.0.0)
+```
+
+*Desktop additionally* references four APIs that no longer exist anywhere in `VsAgentic.UI` — `BannerTheme`, and `ChatWebView.ShowPermissionBanner` / `ShowQuestionCard` / `ShowLoginBanner`, plus the matching view-model events. Banner rendering was reworked after v3.0.15 and Desktop was never updated, so it needs its banner wiring rewritten against the current `ChatWebView`, not just a package fix.
+
+
+
+## Install the updates so that a local VS2026 can use the extension before publishing
+
+Using it for a few days locally, before creating a PR to contribute, can be done with the VSIX installer using this script:
+
+```powershell
+.\scripts\install-local.ps1            # build Release, replace the installed copy
+.\scripts\install-local.ps1 -BumpPatch # same, but bump 3.4.4 -> 3.4.5 first (not needed to pick up a rebuild)
+.\scripts\install-local.ps1 -SkipBuild # reinstall the VSIX already in bin\Release
+```
+
+The script locates VSIXInstaller via `vswhere`, uninstalls the previous copy by Identity Id, then installs the fresh one. It **refuses to run while any `devenv.exe` is alive** — VSIXInstaller cannot replace files that a running IDE has loaded, and a partial install is worse than no install. Close every VS window, including the Experimental Instance.
+
+You will get an unsigned-extension prompt; that is expected for a local build and the script deliberately does not suppress it.
+
+Settings and history survive a reinstall: **Tools → Options → VsAgentic** lives in the VS settings hive, and chat history in `%AppData%\VsAgentic\workspaces\`.
+
+### Why the uninstall step is not optional
+
+**VSIXInstaller silently refuses a package whose Identity Id *and* Version both match an already-installed extension.** It exits non-zero without touching anything. Since every local build carries the same Identity Id, that means an unbumped rebuild installed on its own does *nothing* — you get your old bits and no obvious error.
+
+Uninstalling first is what makes a same-version reinstall work, and the uninstall is immediate rather than deferred to the next VS start: the installer log shows it deleting the extension's files and then its parent directory, after which the install lands in a fresh randomly-named folder. So **you do not need `-BumpPatch` to pick up a rebuild** — the script's uninstall already handles it. `-BumpPatch` exists for the Marketplace-overwrite problem described below, which is a different concern.
+
+Because a failed uninstall degrades into exactly that silent no-op, the script checks the extension directory on disk before and after each step rather than trusting VSIXInstaller's exit code. It will fail loudly if a previous copy survives the uninstall, or if the expected version is not present afterwards.
+
+### Which version actually gets installed
+
+Two versions are in play and they can disagree:
+
+|                                                   | Where it comes from                                   |
+| ------------------------------------------------- | ----------------------------------------------------- |
+| `source.extension.vsixmanifest`                   | What you edit, and what `-BumpPatch` increments       |
+| `extension.vsixmanifest` inside the built `.vsix` | What VSIXInstaller reads, and what VS ends up running |
+
+They drift whenever the manifest is bumped without a completed build — a `-BumpPatch` run that failed at the build step, or any `-SkipBuild` run against a stale `bin\Release`. The trap is that the manifest says one thing while the artifact on disk contains the previous build, so the install "succeeds" and nothing changes.
+
+The script reads the version out of the built `.vsix` and treats *that* as authoritative, erroring out if it disagrees with the manifest. If you hit that error after a `-BumpPatch` that did not finish, just re-run without `-SkipBuild`.
+
+#### Why a *successful* build used to ship the old version
+
+Worth knowing, because the symptom was a green build that changed nothing. The VSSDK packs `obj\<config>\<tfm>\extension.vsixmanifest`, not `source.extension.vsixmanifest` directly. `DetokenizeVsixManifestSource` (Microsoft.VSSDK.BuildTools 17.14.2120) generates that intermediate file **only when it does not already exist** — and it reports the write in `FileWrites` either way, so even a `-v:diag` build log shows the target running normally.
+
+The effect is that on any incremental build, every edit to `source.extension.vsixmanifest` is silently discarded: version, `DisplayName`, `Description`, `Prerequisites`, `Assets`. The packed `.vsix` keeps whatever the manifest said the last time `obj` was clean. Version is the one that bites, because VSIXInstaller keys on it — you bump, the build succeeds, and the `.vsix` is still stamped with the old version, which then refuses to install over itself.
+
+`VsAgentic.VSExtension.csproj` has a `ForceRefreshIntermediateVsixManifest` target that deletes the intermediate when the source manifest is newer, so the detokenizer regenerates it. Its `Inputs`/`Outputs` make it a no-op otherwise. If you ever see the version mismatch error again, delete `obj\<config>\net472\extension.vsixmanifest` by hand and rebuild — that is the whole fix, and a full `Clean` is not necessary.
+
+### Keep your local version ahead of the Marketplace
+
+This is the part that will silently undo your work if you skip it. A local build and the published extension share an Identity Id, so Visual Studio considers them the same extension. If the Marketplace version ever exceeds the one you installed, **VS's automatic extension update replaces your local build with the published one** — usually without you noticing.
+
+Two defences, worth applying together:
+
+1. **Bump the manifest version past the published one.** `-BumpPatch` does this. Because `UpdateChecker` only raises its InfoBar when Marketplace > running, staying ahead also silences the update nag. A local bump is safe: the publish workflow rewrites the version from the git tag, so it cannot corrupt a release.
+2. **Disable automatic extension updates** — Tools → Options → Environment → Extensions.
+
+To check what the Marketplace currently advertises, look at the update checker's own log:
+
+```powershell
+Select-String "marketplace latest" "$env:APPDATA\VsAgentic\logs\updatechecker-*.log" | Select-Object -Last 3
+```
+
+### It said it installed but nothing changed
+
+Work through these in order:
+
+1. **Confirm what is on disk.** The deployment check in the Experimental Instance section above works just as well for a normal install — it lists every VsAgentic folder with its version. Two hits means an old copy survived an uninstall; zero means the install never landed.
+2. **Check the version in that folder.** If it is not the version you just built, you are looking at a stale install, not a broken change — see the two sections above for the two ways that happens.
+3. **Read the installer's own log.** VSIXInstaller writes to `%TEMP%\dd_VSIXInstaller_<timestamp>_<id>.log`. Each invocation produces two files: a small one echoing the command line, and a large one with the actual work. Sort by timestamp and open the large one.
+4. **Rule out VS having updated over you** — if the installed version matches the Marketplace rather than your build, automatic extension updates replaced it. See the section above.
+
+### Doing it by hand
+
+If you would rather not use the script, it is three commands (VS closed):
+
+```powershell
+dotnet build src/VsAgentic.slnx -c Release -v minimal
+
+& "<VS>\Common7\IDE\VSIXInstaller.exe" /q /u:VsAgentic.VSExtension.c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
+& "<VS>\Common7\IDE\VSIXInstaller.exe" src\VsAgentic.VSExtension\bin\Release\net472\VsAgentic.VSExtension.vsix
+```
+
+Resolve `<VS>` with `& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`.
+
+**Do not skip the uninstall.** If you did not bump the version, the install is a no-op for the reason above — you will see a non-zero exit code and no change. If you did bump it, skipping the uninstall tends to leave two extension directories behind, which is the root of the "update banner keeps appearing" symptom in the README. Doing it by hand also means neither step is verified, so check the extension folder on disk afterwards.
+
+## Testing
+
+**There are no test projects and no test runner.** Verification is manual. If you add automated tests, note that the `net472` target rules out some modern tooling, and the solution will need the new project added to `VsAgentic.slnx`.
+
+Until then, the checklist below is the de-facto regression suite. Run the sections that your change touches; run all of it before tagging a release.
+
+### Core conversation
+
+- [ ] Send a message and get a streamed response — text should appear incrementally, not all at once.
+- [ ] Ask a follow-up that depends on the previous turn, to confirm the subprocess is being reused and context survives.
+- [ ] Send a prompt containing **non-ASCII text** (e.g. Cyrillic, CJK, emoji) and confirm it is not corrupted — stdin encoding here has regressed before.
+- [ ] Press **Stop** mid-response and confirm the UI returns to idle and remains usable.
+- [ ] Trigger a tool-heavy request (e.g. "find all TODO comments") and confirm tool steps render with correct pending → success status transitions.
+
+### Permissions and questions
+
+These paths only work when **CLI Permission Mode** is `Default` in Tools → Options — the other modes bypass the prompt entirely.
+
+- [ ] Ask for something that requires a gated tool (a file edit or a shell command) and confirm the permission banner appears.
+- [ ] **Allow** — the tool runs.
+- [ ] **Deny** — the model is told and adapts rather than hanging.
+- [ ] **"Do this instead"** — the custom instruction reaches the model.
+- [ ] **"Allow for this session"** — a second matching request is auto-approved with no banner. Then restart the chat window and confirm the grant is *gone* (it is deliberately per-subprocess and never persisted).
+- [ ] Provoke an `AskUserQuestion` (ask something genuinely ambiguous) and confirm the question card renders, accepts an answer, and the model continues with that answer.
+- [ ] Press **Stop** while a permission banner is open — pending requests should be denied so the dispatcher unblocks.
+
+### Sessions and windows
+
+- [ ] Create a session, exchange messages, close VS, reopen — history is restored and the auto-generated title persists.
+- [ ] Open several chat windows at once; each keeps an independent conversation and its own CLI subprocess.
+- [ ] Rename and delete sessions from the Sessions panel.
+- [ ] Switch solutions while a chat is open — idle windows close, busy ones stay open, and the session list reloads for the new workspace.
+- [ ] Click a file path in a rendered response and confirm it opens at the right line in the editor. Test a `path:42` suffix and an MSYS-style `/c/foo/bar` path.
+
+### Environment failure modes
+
+> **First-run gotcha: set the CLI path in the Experimental Instance.** The Exp instance has its own settings hive, so whatever you configured in your normal VS does **not** carry over. On a fresh Exp instance the path falls back to the default `"claude"`, and you get:
+> 
+> ```
+> Failed to start Claude CLI: The system cannot find the file specified.
+> ```
+> 
+> The bare default cannot work on Windows with an npm-installed CLI. The process is started with `UseShellExecute = false`, so Win32 `CreateProcess` does the lookup — it searches `PATH` but appends only `.exe` to an extensionless name, ignoring `PATHEXT`. npm installs `claude`, `claude.cmd`, and `claude.ps1`; there is no `claude.exe`, so the search fails.
+> 
+> Set **Tools → Options → VsAgentic → General → Claude CLI Path** to the full `.cmd`, e.g. `%AppData%\npm\claude.cmd` (expand it — the options page stores a literal string). Find yours with `(Get-Command claude.cmd).Source`. Resetting the Exp instance wipes this setting.
+> 
+> To confirm which binary a run actually used, grep the log:
+> 
+> ```powershell
+> Select-String "Launching:" "$env:APPDATA\VsAgentic\logs\vsagentic-<date>*.log" | Select-Object -Last 3
+> ```
+> 
+> Both instances write to the same log directory, so Serilog rolls the second one to `vsagentic-<date>_001.log` — check both files when the Exp instance is running alongside your normal VS.
+
+- [ ] Point **Claude CLI Path** at something nonexistent — expect a clear "Failed to start Claude CLI" message, not a silent hang.
+- [ ] Log the CLI out (`claude logout`) and send a message — expect the login banner, and expect the **Login** button to launch an interactive CLI window.
+
+### After touching package versions or dependencies
+
+This is the highest-risk change in the repo. See the "Assembly loading" section of `src/CLAUDE.md` before you start, then:
+
+- [ ] Confirm the extension loads at all in the Experimental Instance — a binding failure usually manifests as the tool window silently failing to open.
+- [ ] Check `%LocalAppData%\VsAgentic\resolver.log` for `no candidate found` entries, which mean a name is missing from `AssemblyResolveBootstrap.AllowList`.
+- [ ] Confirm **GitHub Copilot** and other extensions still work in the same instance. A previous binding-redirect approach broke Copilot process-wide; the current resolver is scoped precisely to avoid that, and it is worth re-verifying.
+- [ ] Inspect the built VSIX and confirm no VS-bundled assemblies (`Microsoft.Extensions.*`, `System.Text.Json`, …) are being shipped.
+
+## Debugging
+
+### Logs
+
+| Path                                                       | Contents                                                                                                                     |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `%AppData%\VsAgentic\logs\vsagentic-<date>.log`            | Main Serilog sink. CLI launch command line, process exit codes, CLI stderr, helper extraction path.                          |
+| `%AppData%\VsAgentic\logs\vsagentic-mcp-helper-<date>.log` | The MCP helper's own log — pipe connection, handshake, every MCP request. Start here when a permission prompt never appears. |
+| `%LocalAppData%\VsAgentic\resolver.log`                    | Assembly-resolve bootstrap only. Written before Serilog exists.                                                              |
+| `%AppData%\VsAgentic\workspaces\<hash>\`                   | Persisted sessions, keyed by SHA-256 of the normalized solution path. Delete a folder to reset one workspace's history.      |
+
+The `[ClaudeCli] Launching:` line in the main log contains the full argument string handed to the CLI — copy it into a terminal to reproduce a spawn problem outside the IDE.
+
+Raw stream-json traffic is **not** logged. Unparseable stdout lines are logged at `Trace`, which the VS host does not emit (its Serilog minimum level is `Debug`, set in `VsAgenticPackage.CreateChatViewModel`). Lower it there, or use the Console host, when you need that detail.
+
+### Attaching to the child processes
+
+The `claude` CLI and `vsagentic-mcp-permissions.exe` are separate processes, so F5 does not attach to them. To debug the helper, use **Debug → Attach to Process** against `vsagentic-mcp-permissions.exe` once a chat window is open, or add a `Debugger.Launch()` at the top of its `Main`. Note that the helper is extracted to `%LocalAppData%\VsAgentic\helpers\<content-hash>\` — the hash changes with every helper rebuild, so old directories accumulate and are safe to delete when no IDE is running.
+
+`ChildProcessTracker` puts the CLI in a Win32 Job Object so it dies with the IDE. If you kill `devenv.exe` from Task Manager, the CLI should go with it; a surviving `claude` process is a bug worth reporting.
+
+## Conventions
+
+- **Versioning** — bump `Version` in `src/VsAgentic.VSExtension/source.extension.vsixmanifest` in the same commit as your change. This is the pattern throughout `git log`, and it makes it possible to tell which build a user is running from the extension folder alone.
+- **Releases** — pushing a `v*.*.*` tag runs `.github/workflows/publish-vsix.yml`, which rewrites the manifest version from the tag, builds, publishes to the VS Marketplace, and cuts a GitHub release with a commit-derived changelog. The tag is the source of truth for the published version.
+- **Architecture** — `src/CLAUDE.md` documents the layering, the CLI conversation loop, the permission/question flow, and the assembly-loading scheme. Read it before changing anything in `VsAgentic.Services/ClaudeCli/` or touching package versions.
+- **Layering** — each project references only the one below it (`VSExtension → UI → Services`). Keep VS SDK types out of `VsAgentic.UI` and `VsAgentic.Services`; the Desktop and Console hosts depend on that separation holding.
+
+## Filing issues and pull requests
+
+- Bugs: <https://github.com/adospace/vs-agentic/issues>
+- Ideas and questions: <https://github.com/adospace/vs-agentic/discussions>
+
+For bug reports, the two logs that help most are `vsagentic-<date>.log` and — for anything permission-related — `vsagentic-mcp-helper-<date>.log`. Include your VS version, the extension version from the manifest, and the output of `claude --version`.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Your feedback makes VsAgentic better! Here's how to get involved:
 - 💡 **Have a feature idea?** [Start a discussion](../../discussions/new?category=ideas)
 - ⭐ **Enjoying the extension?** A star on GitHub goes a long way — thank you!
 - 🗳️ **Marketplace review** — Leaving a review on the Visual Studio Marketplace helps other developers discover VsAgentic.
+- 🛠️ **Want to contribute?** See [CONTRIBUTING.md](CONTRIBUTING.md) for how to build, run, and test the extension locally, on a fork and before raising a PR back to the main repo 
 
 ---
 

--- a/scripts/install-local.ps1
+++ b/scripts/install-local.ps1
@@ -1,0 +1,276 @@
+<#
+.SYNOPSIS
+    Builds VsAgentic and installs it into your real Visual Studio instance for
+    day-to-day use, replacing any previously installed copy.
+
+.DESCRIPTION
+    This is the dogfooding path: use your own build as your daily driver
+    without publishing to the Marketplace.
+
+    All Visual Studio instances must be closed — VSIXInstaller cannot replace
+    an extension whose files are loaded, and the script refuses to run rather
+    than leave you with a half-installed extension.
+
+    Because the local build and the published extension share an Identity Id,
+    Visual Studio treats them as the same extension. If the Marketplace
+    version ever exceeds yours, VS's automatic extension update will silently
+    replace your local build. Use -BumpPatch to stay ahead, and consider
+    disabling automatic extension updates in
+    Tools > Options > Environment > Extensions.
+
+    Reinstalling the same version works because the script uninstalls first.
+    VSIXInstaller rejects a package whose Identity Id and Version both match an
+    already-installed extension, so an unbumped rebuild installed on its own
+    would silently do nothing. The script verifies the uninstall and the install
+    against the extension directory on disk rather than trusting exit codes.
+
+.PARAMETER BumpPatch
+    Increment the patch component of the version in source.extension.vsixmanifest
+    before building. Keeps your local build ahead of the published version so VS
+    never overwrites it and the update InfoBar stays quiet. Not required to pick
+    up a rebuild - see above.
+
+.PARAMETER SkipBuild
+    Install the VSIX already present in bin\Release without rebuilding.
+
+.PARAMETER Configuration
+    Build configuration. Defaults to Release.
+
+.EXAMPLE
+    .\scripts\install-local.ps1
+    Build and install the current version.
+
+.EXAMPLE
+    .\scripts\install-local.ps1 -BumpPatch
+    Bump 3.4.4 to 3.4.5, build, and install.
+#>
+[CmdletBinding()]
+param(
+    [switch]$BumpPatch,
+    [switch]$SkipBuild,
+    [string]$Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Identity Id from source.extension.vsixmanifest. VSIXInstaller uninstalls by
+# this, not by display name.
+$ExtensionId = 'VsAgentic.VSExtension.c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f'
+
+$repoRoot    = Split-Path -Parent $PSScriptRoot
+$solution    = Join-Path $repoRoot 'src\VsAgentic.slnx'
+$manifest    = Join-Path $repoRoot 'src\VsAgentic.VSExtension\source.extension.vsixmanifest'
+$vsixPath    = Join-Path $repoRoot "src\VsAgentic.VSExtension\bin\$Configuration\net472\VsAgentic.VSExtension.vsix"
+
+function Write-Step($message) {
+    Write-Host ""
+    Write-Host "==> $message" -ForegroundColor Cyan
+}
+
+# Reads the version baked into a built .vsix. This is the only version that
+# matters: the source manifest can be ahead of the artifact (a -BumpPatch run
+# that bumped and then failed to build, or -SkipBuild against a stale bin).
+function Get-VsixVersion($path) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($path)
+    try {
+        $entry = $zip.Entries | Where-Object { $_.Name -eq 'extension.vsixmanifest' } | Select-Object -First 1
+        if (-not $entry) { throw "'$path' contains no extension.vsixmanifest." }
+        $reader = New-Object System.IO.StreamReader($entry.Open())
+        try { [xml]$x = $reader.ReadToEnd() } finally { $reader.Dispose() }
+        return $x.PackageManifest.Metadata.Identity.Version
+    } finally {
+        $zip.Dispose()
+    }
+}
+
+# Every per-user extension directory currently holding our Identity Id.
+# More than one means a previous uninstall left a copy behind.
+function Get-InstalledCopies {
+    $root = Join-Path $env:LocalAppData 'Microsoft\VisualStudio'
+    if (-not (Test-Path $root)) { return @() }
+    return @(
+        Get-ChildItem $root -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object { Join-Path $_.FullName 'Extensions' } |
+            Where-Object { Test-Path $_ } |
+            Get-ChildItem -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                $m = Join-Path $_.FullName 'extension.vsixmanifest'
+                if (Test-Path $m) {
+                    try {
+                        [xml]$x = Get-Content $m -ErrorAction Stop
+                        if ($x.PackageManifest.Metadata.Identity.Id -eq $ExtensionId) {
+                            [pscustomobject]@{
+                                Path    = $_.FullName
+                                Version = $x.PackageManifest.Metadata.Identity.Version
+                            }
+                        }
+                    } catch { }
+                }
+            }
+    )
+}
+
+# --- 1. Refuse to run while Visual Studio is open ------------------------------
+# VSIXInstaller will either fail or half-apply against a running IDE, and the
+# Experimental Instance counts too.
+$running = @(Get-Process -Name devenv -ErrorAction SilentlyContinue)
+if ($running.Count -gt 0) {
+    Write-Host "Visual Studio is running ($($running.Count) instance(s), PID: $($running.Id -join ', '))." -ForegroundColor Red
+    Write-Host "Close every VS window - including any Experimental Instance - and run this again." -ForegroundColor Red
+    exit 1
+}
+
+# --- 2. Locate VSIXInstaller.exe ----------------------------------------------
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vswhere)) {
+    throw "vswhere.exe not found at '$vswhere'. Is Visual Studio installed?"
+}
+
+$vsInstallPath = & $vswhere -latest -prerelease -property installationPath
+if ([string]::IsNullOrWhiteSpace($vsInstallPath)) {
+    throw "vswhere could not locate a Visual Studio installation."
+}
+
+$vsixInstaller = Join-Path $vsInstallPath 'Common7\IDE\VSIXInstaller.exe'
+if (-not (Test-Path $vsixInstaller)) {
+    throw "VSIXInstaller.exe not found at '$vsixInstaller'."
+}
+Write-Host "Visual Studio: $vsInstallPath" -ForegroundColor DarkGray
+
+# --- 3. Optionally bump the patch version -------------------------------------
+if ($BumpPatch) {
+    Write-Step "Bumping version"
+
+    # Edited as text, not via [xml].Save(): the XmlDocument round-trip reflows
+    # every wrapped attribute onto one line and drops the trailing newline,
+    # turning a one-digit bump into a whole-file diff.
+    $utf8Bom = New-Object System.Text.UTF8Encoding($true)
+    $text    = [System.IO.File]::ReadAllText($manifest)
+    $pattern = '(?<head><Identity\b[^>]*?\bVersion=")(?<ver>[^"]+)(?<tail>")'
+
+    $match = [regex]::Match($text, $pattern)
+    if (-not $match.Success) {
+        throw "Could not find the Identity Version attribute in '$manifest'; bump it by hand."
+    }
+
+    $current = $match.Groups['ver'].Value
+    $parts   = $current.Split('.')
+    if ($parts.Count -lt 3) {
+        throw "Version '$current' in the manifest is not in major.minor.patch form; bump it by hand."
+    }
+    $parts[2] = ([int]$parts[2] + 1).ToString()
+    $new = $parts -join '.'
+
+    $text = $text.Remove($match.Index, $match.Length).Insert($match.Index, "$($match.Groups['head'].Value)$new$($match.Groups['tail'].Value)")
+    [System.IO.File]::WriteAllText($manifest, $text, $utf8Bom)
+
+    Write-Host "  $current -> $new" -ForegroundColor Green
+    Write-Host "  (the publish workflow rewrites this from the git tag, so a local bump is safe)" -ForegroundColor DarkGray
+}
+
+[xml]$manifestXml = Get-Content $manifest
+$manifestVersion = $manifestXml.PackageManifest.Metadata.Identity.Version
+Write-Host "Manifest version: $manifestVersion" -ForegroundColor DarkGray
+
+$before = @(Get-InstalledCopies)
+if ($before.Count -eq 0) {
+    Write-Host "Currently installed: none" -ForegroundColor DarkGray
+} else {
+    Write-Host "Currently installed: $(($before | ForEach-Object { $_.Version }) -join ', ')" -ForegroundColor DarkGray
+}
+
+# --- 4. Build -----------------------------------------------------------------
+if ($SkipBuild) {
+    Write-Step "Skipping build (-SkipBuild)"
+} else {
+    Write-Step "Building $Configuration"
+    & dotnet build $solution -c $Configuration -v minimal
+    if ($LASTEXITCODE -ne 0) {
+        throw "Build failed with exit code $LASTEXITCODE."
+    }
+}
+
+if (-not (Test-Path $vsixPath)) {
+    throw "VSIX not found at '$vsixPath'. Build the solution first, or drop -SkipBuild."
+}
+$sizeMb = [math]::Round((Get-Item $vsixPath).Length / 1MB, 2)
+Write-Host "VSIX: $vsixPath ($sizeMb MB)" -ForegroundColor DarkGray
+
+# The artifact, not the manifest, is what gets installed. They drift whenever a
+# -BumpPatch run bumps the version and then doesn't complete a build, and
+# -SkipBuild can't reconcile them at all.
+$version = Get-VsixVersion $vsixPath
+Write-Host "Version to install: $version" -ForegroundColor DarkGray
+if ($version -ne $manifestVersion) {
+    Write-Host ""
+    Write-Host "The built VSIX is $version but source.extension.vsixmanifest says $manifestVersion." -ForegroundColor Red
+    if ($SkipBuild) {
+        throw "Stale VSIX in bin\$Configuration. Drop -SkipBuild so the $manifestVersion artifact gets built."
+    }
+    # The VSSDK packs obj\<config>\<tfm>\extension.vsixmanifest, and
+    # DetokenizeVsixManifestSource only writes that file when it is missing.
+    # VsAgentic.VSExtension.csproj has a target to clear it, so reaching this
+    # point means that target is not doing its job.
+    Write-Host "Delete this and rebuild:" -ForegroundColor Red
+    Write-Host "  src\VsAgentic.VSExtension\obj\$Configuration\net472\extension.vsixmanifest" -ForegroundColor Red
+    throw "The build did not pick up the manifest version."
+}
+
+# --- 5. Uninstall the previous copy -------------------------------------------
+# Leaving the old one in place can produce two extension directories, which is
+# the cause of the "update banner keeps appearing" symptom in the README.
+# A missing extension is not an error here.
+#
+# This step is also what makes reinstalling the *same* version work at all:
+# VSIXInstaller refuses a package whose Id and Version already match an
+# installed extension, so without a preceding uninstall an unbumped rebuild is
+# a no-op. Hence the disk check below rather than trusting the exit code - a
+# silently failed uninstall turns the install into that no-op.
+Write-Step "Uninstalling any previously installed VsAgentic"
+if ($before.Count -eq 0) {
+    Write-Host "  Nothing installed - skipping." -ForegroundColor DarkGray
+} else {
+    $uninstall = Start-Process -FilePath $vsixInstaller `
+                               -ArgumentList @('/q', "/u:$ExtensionId") `
+                               -Wait -PassThru -NoNewWindow
+
+    $left = @(Get-InstalledCopies)
+    if ($left.Count -gt 0) {
+        Write-Host "Uninstall left $($left.Count) copy/copies on disk (installer exit code $($uninstall.ExitCode)):" -ForegroundColor Red
+        $left | ForEach-Object { Write-Host "  $($_.Version)  $($_.Path)" -ForegroundColor Red }
+        Write-Host "Installing over these would be a no-op. See the newest %TEMP%\dd_VSIXInstaller_*.log." -ForegroundColor Red
+        throw "Could not remove the previously installed VsAgentic."
+    }
+    Write-Host "  Removed (exit code $($uninstall.ExitCode))." -ForegroundColor Green
+}
+
+# --- 6. Install ---------------------------------------------------------------
+# Not /q: the unsigned-extension prompt needs to be visible and accepted.
+Write-Step "Installing $version"
+Write-Host "Check for a popup on the desktop from VS Installer window that require your input"
+$install = Start-Process -FilePath $vsixInstaller `
+                         -ArgumentList @($vsixPath) `
+                         -Wait -PassThru -NoNewWindow
+if ($install.ExitCode -ne 0) {
+    throw "VSIXInstaller failed with exit code $($install.ExitCode). See the newest %TEMP%\dd_VSIXInstaller_*.log."
+}
+
+# Exit code 0 is not proof: verify the bits actually landed.
+$after = @(Get-InstalledCopies)
+if ($after.Count -eq 0) {
+    throw "VSIXInstaller reported success but no VsAgentic extension directory exists. See the newest %TEMP%\dd_VSIXInstaller_*.log."
+}
+$wrong = @($after | Where-Object { $_.Version -ne $version })
+if ($wrong.Count -gt 0) {
+    $wrong | ForEach-Object { Write-Host "  found $($_.Version) at $($_.Path)" -ForegroundColor Red }
+    throw "Expected $version to be installed but found the above instead."
+}
+Write-Host "  Verified at $($after[0].Path)" -ForegroundColor DarkGray
+
+Write-Step "Done"
+Write-Host "VsAgentic $version installed. Start Visual Studio and open View > Other Windows > VsAgentic." -ForegroundColor Green
+Write-Host ""
+Write-Host "Settings and chat history are preserved across reinstalls:" -ForegroundColor DarkGray
+Write-Host "  Tools > Options > VsAgentic  (per-instance settings hive)" -ForegroundColor DarkGray
+Write-Host "  %AppData%\VsAgentic\workspaces  (session history)" -ForegroundColor DarkGray

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+VsAgentic is a Visual Studio 2026 extension that embeds a Claude chat panel in the IDE. It does **not** call the Anthropic API — it drives the `claude` CLI as a long-lived child process in bidirectional stream-json mode and renders the resulting event stream as chat UI. Authentication is entirely the CLI's (subscription-based); `ANTHROPIC_API_KEY` is deliberately cleared before spawning.
+
+## Build & run
+
+```powershell
+dotnet restore src/VsAgentic.slnx
+dotnet build src/VsAgentic.slnx -c Release -v minimal   # produces the VSIX under VsAgentic.VSExtension/bin/<config>/
+```
+
+- **F5 in Visual Studio** launches the VS Experimental Instance with the VSIX deployed. Deployment hinges on `<DeployExtension>` in `VsAgentic.VSExtension.csproj`, *not* on the `<Deploy Solution="Debug|*" />` entry in `VsAgentic.slnx`: `Microsoft.VisualStudio.Extensibility.Build.targets` defaults `DeployExtension` to `false` and is imported after the VSSDK targets that default it to `true`, so this hybrid VSSDK + VisualStudio.Extensibility project must set it explicitly. It is conditioned on `'$(MSBuildRuntimeType)' != 'Core'` because the VSSDK targets hard-error on `dotnet build`. Don't remove that condition — it would break CI.
+- **`VsAgentic.Desktop`** (WPF) and **`VsAgentic.Console`** are standalone apps over `AddVsAgenticServices`, intended for iterating on the service/UI layers without an Experimental Instance. **Both are currently not contolled by `VsAgentic.slnx`**, so nothing builds them. Both fail restore with `NU1107`: `Microsoft.Extensions.Hosting 10.0.5` wants `System.Text.Json >= 10.0.5` but `VsAgentic.Services`/`VsAgentic.UI` strict-pin it to `[10.0.0]` (fix: a direct `System.Text.Json` reference in the app — the pin only matters inside devenv). `Desktop` is additionally stale since v3.0.15, referencing `BannerTheme` and `ChatWebView.ShowPermissionBanner`/`ShowQuestionCard`/`ShowLoginBanner`, none of which exist any more. Don't recommend either as a verification path without spending time shaping them up for this.
+- There are **no test projects**. Verification is manual, via the Experimental Instance (F5).
+- `ForceRefreshIntermediateVsixManifest` in `VsAgentic.VSExtension.csproj` deletes `obj\<config>\<tfm>\extension.vsixmanifest` when `source.extension.vsixmanifest` is newer. `DetokenizeVsixManifestSource` only generates that intermediate file when it's absent — without the target, every manifest edit (version, `DisplayName`, `Assets`, …) is silently dropped on incremental builds while the build still reports success. Don't remove it.
+
+Everything targets `net472` (VS extension constraint) with `LangVersion latest`; `PolySharp` supplies the missing modern BCL attributes.
+
+### Release
+
+Pushing a `v*.*.*` tag triggers `.github/workflows/publish-vsix.yml`, which rewrites `source.extension.vsixmanifest`'s version from the tag, builds, publishes to the VS Marketplace, and cuts a GitHub release. The repo convention (see `git log`) is to bump the manifest version in the same commit as the change.
+
+### Logs
+
+- `%AppData%\VsAgentic\logs\vsagentic-<date>.log` — main Serilog sink (and the MCP helper's own log).
+- `%LocalAppData%\VsAgentic\resolver.log` — assembly-resolve bootstrap only (runs before Serilog exists).
+- `%AppData%\VsAgentic\workspaces\<hash>\` — persisted sessions, keyed by SHA-256 of the normalized solution path.
+
+## Architecture
+
+Four layers, each project referencing only the one below it:
+
+```
+VsAgentic.VSExtension  →  VsAgentic.UI  →  VsAgentic.Services
+(VSIX, tool windows,      (WPF controls,    (CLI process host,
+ options, package)         MVVM, WebView2)   brokers, session store)
+
+VsAgentic.Services.McpPermissionServer — separate exe, embedded as a zip resource
+```
+
+`AddVsAgenticServices` (`Services/DependencyInjection/ServiceCollectionExtensions.cs`) is the single composition entry point used by all three hosts. In the VS extension, `VsAgenticPackage.CreateChatViewModel` builds a **fresh `ServiceProvider` per chat window** — so each chat tool window owns its own CLI subprocess, brokers, and pipe server.
+
+### The CLI conversation loop
+
+1. `ClaudeCliProcessHost` (singleton per chat window) spawns `claude -p --input-format stream-json --output-format stream-json --verbose --permission-mode <mode> --permission-prompt-tool mcp__vsagentic__approval_prompt --strict-mcp-config --mcp-config <tempfile>`. `-p` (print mode) is mandatory — the stream-json flags and `--permission-prompt-tool` only apply there.
+2. All stdin writes funnel through one `Channel<string>` serviced by a single writer task; stdout lines are parsed to `JsonElement` and pushed onto a second channel.
+3. `ClaudeCliChatService` runs one dispatcher task over that channel and routes events to the single `TurnState` that's active (turns are serialized by the UI's `IsBusy` gate). `SendMessageAsync` writes one user line and yields text deltas until the matching `result` event.
+4. The process is reused across turns; session state lives inside the CLI. On restart, `SetResumeSessionId` + `--resume` restores context.
+
+Argument-order caveat documented in `BuildArguments`: `--resume` must precede `--append-system-prompt`, because a `.cmd`/`.bat` CLI target routes through `cmd.exe`, which can truncate the argument string at embedded newlines.
+
+### Permission & question flow
+
+This is the least obvious part of the system. The CLI can't call back into the extension directly, so:
+
+```
+claude CLI  --(stdio MCP)-->  vsagentic-mcp-permissions.exe  --(named pipe)-->  extension process
+                                                                                      |
+                                              PermissionPipeServer → IPermissionBroker / IUserQuestionBroker
+                                                                                      |
+                                                              ChatSessionViewModel → banner UI → Allow/Deny
+```
+
+- The helper exe's whole `bin` folder is zipped into `VsAgentic.Services` as an embedded resource (`EmbedMcpHelper` target) and extracted at runtime to `%LocalAppData%\VsAgentic\helpers\<content-hash>\`. The hash directory exists so two IDE instances on different extension versions don't fight over locked DLLs.
+- Pipe name and shared secret are per-process GUIDs passed to the helper via env vars in the generated `--mcp-config`.
+- Wire format is newline-delimited JSON, two shapes only — see the doc comment on `PermissionPipeServer`.
+- `AskUserQuestion` rides the same channel: the answers come back as the *allow* decision's `updatedInput`, not as a side-channel `tool_result`. That's the documented Anthropic flow and keeps the model's tool call resolving naturally.
+- "Allow for this session" is **extension-side only** (`IPermissionBroker.RememberAllow`) — the CLI always sees a plain `allow`, and nothing is written to user settings. Remembered allows are cleared whenever the subprocess restarts, since a new process is a new session.
+- The helper exe hand-rolls its JSON escaping (`JsonEscape` in its `Program.cs`) because `JsonSerializer.Serialize(string)` drags in `DefaultJsonTypeInfoResolver`, which fails to load on net472 inside the CLI's spawn environment.
+
+### Assembly loading — read before touching package versions
+
+Visual Studio ships its own `Microsoft.Extensions.*`, `System.Text.Json`, `Microsoft.Bcl.AsyncInterfaces`, etc. in `Common7\IDE\PublicAssemblies` / `PrivateAssemblies`, and .NET Framework's strong-name binder rejects any patch mismatch. The scheme:
+
+- Every VS-bundled package is **strict-pinned to `[10.0.0]`** (the .NET 10 GA floor) with `ExcludeAssets="runtime"` in `VsAgentic.VSExtension.csproj`, so we compile against the floor and ship nothing.
+- `AssemblyResolveBootstrap` (a `[ModuleInitializer]` in the extension) hooks `AppDomain.AssemblyResolve` and probes VS's assembly folders for whatever version is actually on disk, for an explicit allow-list only.
+- **Adding a VS-bundled dependency requires two edits:** an explicit pinned `PackageReference` in `VsAgentic.VSExtension.csproj` *and* the simple name in `AssemblyResolveBootstrap.AllowList`. The host-level `PackageReference` is required even if the dependency is only used by `VsAgentic.Services` — transitive packages don't inherit `ExcludeAssets` and get re-deposited into the output folder otherwise.
+- `Serilog` is pinned to exactly `4.2.0` (not VS-bundled, so it ships) because `Serilog.Extensions.Logging` 10.0.0 and `Serilog.Sinks.File` 7.0.0 were compiled against that exact assembly version.
+
+### UI rendering
+
+Chat content is **not** WPF-rendered. `ChatWebView` hosts a WebView2 that loads an embedded HTML template with showdown.js inlined (`VsAgentic.UI/Assets/`), and the view model pushes messages/updates into it via events (`MessageAdded`, `MessageContentUpdated`, …). Operations issued before `NavigationCompleted` are queued in `_pendingOps` and replayed. Clicks on file links post back through `WebMessageReceived` → `ChatWebView.FileOpenRequested` → `VsAgenticPackage.OnFileOpenRequested`, which normalizes MSYS-style `/c/foo` paths and `:line` suffixes before opening the document.
+
+Banners (permission, login, question card) are real WPF: view models in `VsAgentic.UI/ViewModels/Banners/`, controls in `VsAgentic.VSExtension/ToolWindows/Banners/`. `IOutputListener` carries tool-step start/update/complete events from the service layer up to the chat item list.
+
+Concurrency notes worth respecting: `OpenOrActivateSessionAsync` serializes window creation behind `_openSessionGate` because concurrent WebView2 initialization deadlocks the UI thread; `ChildProcessTracker` assigns the CLI to a Win32 Job Object so it dies with a crashed IDE.

--- a/src/VsAgentic.Services/Abstractions/IChatService.cs
+++ b/src/VsAgentic.Services/Abstractions/IChatService.cs
@@ -23,6 +23,27 @@ public interface IChatService
     decimal? GetSessionCost();
 
     /// <summary>
+    /// The model the CLI reported for the current session (e.g. "claude-opus-5"),
+    /// taken from the <c>system/init</c> event. Null until the CLI process has
+    /// started and emitted that event — i.e. before the first message is sent.
+    /// </summary>
+    string? CurrentModel { get; }
+
+    /// <summary>
+    /// The CLI's own session id, once one exists — either restored from persisted
+    /// history or assigned when the session started. Lets the host locate the
+    /// CLI's transcript for this session.
+    /// </summary>
+    string? CliSessionId { get; }
+
+    /// <summary>
+    /// Raised when <see cref="CurrentModel"/> changes — on session start and
+    /// again after a process restart, which can pick up a different model.
+    /// Raised on a background thread; hosts must marshal to the UI thread.
+    /// </summary>
+    event Action<string?>? ModelChanged;
+
+    /// <summary>
     /// Raised when the underlying CLI returned an authentication / login-required
     /// error. The string argument is the original error text from the CLI so the
     /// host can surface it to the user. Hosts should respond by showing a login

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
@@ -42,6 +42,7 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
     private readonly ILogger _logger;
 
     private string? _cliSessionId;
+    private string? _currentModel;
     private decimal _cumulativeCostUsd;
     private Task? _dispatcherTask;
     private readonly object _dispatcherLock = new object();
@@ -138,6 +139,13 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         ClearActiveTurn(turn);
     }
 
+    private void MarkTurnActivity()
+    {
+        TurnState? turn;
+        lock (_activeTurnLock) { turn = _activeTurn; }
+        if (turn != null) turn.LastActivityUtc = DateTime.UtcNow;
+    }
+
     private void ClearActiveTurn(TurnState turn)
     {
         lock (_activeTurnLock)
@@ -206,7 +214,11 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
                 return;
 
             case "user":
-                // The CLI echoes user messages and tool_results; nothing to do here.
+                // The CLI echoes user messages and tool_results; nothing to render.
+                // The echo is still worth timestamping: a tool_result coming back is
+                // the moment control returns to the model, which is where the next
+                // thinking block's clock should start.
+                MarkTurnActivity();
                 return;
 
             case "result":
@@ -218,11 +230,31 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
     private void HandleSystemEvent(JsonElement evt)
     {
         var subtype = evt.TryGetProperty("subtype", out var s) ? s.GetString() : null;
+
+        if (subtype == "thinking_tokens")
+        {
+            HandleThinkingTokensEvent(evt);
+            return;
+        }
+
         if (subtype != "init") return;
         if (evt.TryGetProperty("session_id", out var sid))
         {
             _cliSessionId = sid.GetString();
             _logger.LogDebug("[ClaudeCli] Session started: {SessionId}", _cliSessionId);
+        }
+        // The model the CLI actually resolved for this session — surfaced in the
+        // input bar's status strip. It can differ between process starts (user
+        // changed their default, a fallback kicked in), so raise on every change.
+        if (evt.TryGetProperty("model", out var modelProp) && modelProp.ValueKind == JsonValueKind.String)
+        {
+            var model = modelProp.GetString();
+            if (!string.Equals(model, _currentModel, StringComparison.Ordinal))
+            {
+                _currentModel = model;
+                _logger.LogInformation("[ClaudeCli] Session model: {Model}", model);
+                try { ModelChanged?.Invoke(model); } catch { }
+            }
         }
         // Diagnostic: dump the available tool names so we can verify whether
         // AskUserQuestion is registered in headless mode.
@@ -273,17 +305,73 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         }
     }
 
+    /// <summary>
+    /// The CLI reports thinking progress as <c>system</c>/<c>thinking_tokens</c> events
+    /// while the model is still thinking. This is the only live signal we get: the
+    /// assistant message's thinking block arrives afterwards with its text redacted to
+    /// a bare signature (see <see cref="HandleThinkingBlock"/>), so it can neither open
+    /// the item nor time it.
+    /// </summary>
+    private void HandleThinkingTokensEvent(JsonElement evt)
+    {
+        TurnState? turn;
+        lock (_activeTurnLock) { turn = _activeTurn; }
+        if (turn == null) return;
+
+        if (evt.TryGetProperty("estimated_tokens", out var tp) && tp.ValueKind == JsonValueKind.Number)
+            turn.ThinkingTokens = tp.GetInt32();
+
+        if (turn.ThinkingItem == null)
+        {
+            turn.ThinkingStartTime = turn.LastActivityUtc;
+            turn.ThinkingItem = new OutputItem
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                ToolName = "Thinking",
+                Title = "Thinking...",
+                Status = OutputItemStatus.Pending
+            };
+            _outputListener.OnStepStarted(turn.ThinkingItem);
+        }
+
+        turn.ThinkingLastUpdateUtc = DateTime.UtcNow;
+        turn.ThinkingItem.Title = FormatThinkingProgress(turn);
+        _outputListener.OnStepUpdated(turn.ThinkingItem);
+    }
+
+    private static int ThinkingElapsedSeconds(TurnState turn, DateTime end)
+        => turn.ThinkingStartTime.HasValue
+            ? (int)(end - turn.ThinkingStartTime.Value).TotalSeconds
+            : 0;
+
+    private static string FormatThinkingProgress(TurnState turn)
+    {
+        var elapsed = ThinkingElapsedSeconds(turn, DateTime.UtcNow);
+        var tokens = turn.ThinkingTokens > 0 ? $" ({turn.ThinkingTokens:N0} tokens)" : "";
+        return elapsed > 0 ? $"Thinking for {elapsed}s{tokens}" : $"Thinking...{tokens}";
+    }
+
     private void HandleThinkingBlock(TurnState turn, JsonElement block)
     {
         FinalizeResponseItem(turn);
         FinalizeToolItem(turn);
 
+        // Redacted thinking: the CLI ships the block with an empty "thinking" and a
+        // bare signature, so there is no text to render. The thinking_tokens events
+        // have already opened the item — leave it for the following text/tool block
+        // to finalize rather than tearing it down here.
         var thinking = block.TryGetProperty("thinking", out var tp) ? tp.GetString() ?? "" : "";
         if (string.IsNullOrEmpty(thinking)) return;
 
         if (turn.ThinkingItem == null)
         {
-            turn.ThinkingStartTime = DateTime.UtcNow;
+            // Thinking blocks arrive fully formed — the CLI is not run with
+            // --include-partial-messages, so by the time we see one the model has
+            // already finished thinking and DateTime.UtcNow would always yield 0s.
+            // Measure from the last thing we observed instead (turn start, the
+            // previous block, or a tool handing control back), which brackets the
+            // wall time the model spent producing this block.
+            turn.ThinkingStartTime = turn.LastActivityUtc;
             turn.ThinkingItem = new OutputItem
             {
                 Id = Guid.NewGuid().ToString("N"),
@@ -295,10 +383,10 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         }
 
         turn.ThinkingBuilder.Append(thinking);
-        var elapsed = (int)(DateTime.UtcNow - turn.ThinkingStartTime!.Value).TotalSeconds;
+        turn.ThinkingLastUpdateUtc = DateTime.UtcNow;
         turn.ThinkingItem.Delta = thinking;
         turn.ThinkingItem.Body = turn.ThinkingBuilder.ToString();
-        turn.ThinkingItem.Title = elapsed > 0 ? $"Thought for {elapsed}s" : "Thinking...";
+        turn.ThinkingItem.Title = FormatThinkingProgress(turn);
         _outputListener.OnStepUpdated(turn.ThinkingItem);
     }
 
@@ -327,6 +415,7 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         turn.ResponseItem.Body = turn.ResponseBuilder.ToString();
         _outputListener.OnStepUpdated(turn.ResponseItem);
         turn.TextDeltas.Writer.TryWrite(text);
+        turn.LastActivityUtc = DateTime.UtcNow;
     }
 
     private Task HandleToolUseBlockAsync(TurnState turn, JsonElement block)
@@ -370,6 +459,7 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
             Body = toolBody
         };
         _outputListener.OnStepStarted(turn.ToolItem);
+        turn.LastActivityUtc = DateTime.UtcNow;
         return Task.CompletedTask;
     }
 
@@ -390,6 +480,7 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         turn.ToolItem.Delta = null;
         _outputListener.OnStepCompleted(turn.ToolItem);
         turn.ToolItem = null;
+        turn.LastActivityUtc = DateTime.UtcNow;
     }
 
     private void HandleResultEvent(JsonElement evt)
@@ -445,13 +536,21 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
     private void FinalizeThinkingItem(TurnState turn)
     {
         if (turn.ThinkingItem == null) return;
-        var elapsed = turn.ThinkingStartTime.HasValue ? (int)(DateTime.UtcNow - turn.ThinkingStartTime.Value).TotalSeconds : 0;
+        // End at the last sign of thinking, not at finalize time: the item is closed by
+        // the block that follows it, and the wait for that block is response latency
+        // rather than thinking.
+        var elapsed = ThinkingElapsedSeconds(turn, turn.ThinkingLastUpdateUtc ?? DateTime.UtcNow);
+        var tokens = turn.ThinkingTokens > 0 ? $" ({turn.ThinkingTokens:N0} tokens)" : "";
         turn.ThinkingItem.Status = OutputItemStatus.Success;
-        turn.ThinkingItem.Title = $"Thought for {elapsed}s";
+        turn.ThinkingItem.Title = $"Thought for {elapsed}s{tokens}";
         turn.ThinkingItem.Delta = null;
         _outputListener.OnStepCompleted(turn.ThinkingItem);
         turn.ThinkingItem = null;
+        turn.ThinkingStartTime = null;
+        turn.ThinkingLastUpdateUtc = null;
+        turn.ThinkingTokens = 0;
         turn.ThinkingBuilder.Clear();
+        turn.LastActivityUtc = DateTime.UtcNow;
     }
 
     private void FinalizeResponseItem(TurnState turn)
@@ -724,10 +823,21 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
 
     public decimal? GetSessionCost() => _cumulativeCostUsd > 0 ? _cumulativeCostUsd : null;
 
+    public string? CurrentModel => _currentModel;
+
+    public string? CliSessionId => _cliSessionId;
+
+    public event Action<string?>? ModelChanged;
+
     public void ClearHistory()
     {
         _cliSessionId = null;
         _cumulativeCostUsd = 0;
+        if (_currentModel != null)
+        {
+            _currentModel = null;
+            try { ModelChanged?.Invoke(null); } catch { }
+        }
         _host.Stop();
         lock (_dispatcherLock) { _dispatcherTask = null; }
         _logger.LogInformation("[ClaudeCli] Session cleared (process killed)");
@@ -735,7 +845,10 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
 
     public string SerializeHistory()
     {
-        return JsonSerializer.Serialize(new { cliSessionId = _cliSessionId });
+        // The model is persisted alongside the session id because --resume keeps a
+        // session on the model it was created with, so the *current* configured
+        // default is not a valid stand-in when this session is reopened later.
+        return JsonSerializer.Serialize(new { cliSessionId = _cliSessionId, model = _currentModel });
     }
 
     public void RestoreHistory(string serializedHistory)
@@ -747,6 +860,20 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
             {
                 _cliSessionId = sid.GetString();
                 _logger.LogInformation("[ClaudeCli] Restored session: {SessionId}", _cliSessionId);
+            }
+
+            // Sessions saved before this field existed simply won't have it; the
+            // host then falls back to reading the CLI's transcript.
+            if (doc.RootElement.TryGetProperty("model", out var m)
+                && m.ValueKind == JsonValueKind.String)
+            {
+                var model = m.GetString();
+                if (!string.IsNullOrWhiteSpace(model) && !string.Equals(model, _currentModel, StringComparison.Ordinal))
+                {
+                    _currentModel = model;
+                    _logger.LogDebug("[ClaudeCli] Restored session model: {Model}", model);
+                    try { ModelChanged?.Invoke(model); } catch { }
+                }
             }
         }
         catch (JsonException)
@@ -815,6 +942,19 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         public OutputItem? ThinkingItem;
         public StringBuilder ThinkingBuilder = new StringBuilder();
         public DateTime? ThinkingStartTime;
+
+        /// <summary>Latest <c>estimated_tokens</c> from the CLI's thinking_tokens events.</summary>
+        public int ThinkingTokens;
+
+        /// <summary>When thinking last showed signs of life; the end point for the duration.</summary>
+        public DateTime? ThinkingLastUpdateUtc;
+
+        /// <summary>
+        /// When we last saw output from the CLI for this turn — turn start, a
+        /// completed block, or a tool result handing control back to the model.
+        /// Used as the start point for thinking-duration measurement.
+        /// </summary>
+        public DateTime LastActivityUtc = DateTime.UtcNow;
 
         public OutputItem? ResponseItem;
         public StringBuilder ResponseBuilder = new StringBuilder();

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliProcessHost.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliProcessHost.cs
@@ -95,6 +95,11 @@ public sealed class ClaudeCliProcessHost : IDisposable
         // Tear down anything stale from a prior crashed run.
         TearDownLocked();
 
+        // A fresh CLI process is a fresh session from Claude's point of view,
+        // so any "allow for the rest of the session" grants the user made
+        // against the previous process no longer apply.
+        _permissionBroker.ClearRememberedAllows();
+
         _runCts = new CancellationTokenSource();
 
         // Start the in-process pipe server before launching the CLI so the

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeModelResolver.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeModelResolver.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace VsAgentic.Services.ClaudeCli;
+
+/// <summary>
+/// Best-effort, zero-cost lookup of the model the CLI will use, for display in
+/// the input bar before the first message has been sent.
+///
+/// The CLI only reports its resolved model in the <c>system/init</c> event, and
+/// that event is emitted when the first user message arrives — not at process
+/// start (verified: a stream-json process left idle emits nothing). Every way of
+/// forcing an early init costs a real API call, including <c>--max-budget-usd</c>,
+/// which aborts only *after* the first request. So to show the model at window
+/// load we re-implement the CLI's settings precedence over the same files it
+/// reads.
+///
+/// This is a preview, not the truth: <see cref="ClaudeCliChatService.ModelChanged"/>
+/// overwrites it with the authoritative value as soon as the real init arrives.
+/// Anything this can't determine returns null, and the caller shows nothing —
+/// never a guess.
+/// </summary>
+public static class ClaudeModelResolver
+{
+    /// <summary>
+    /// Resolves the model a *previously started* session actually ran on, by
+    /// reading the CLI's own transcript for that session id.
+    ///
+    /// This matters because <c>--resume</c> keeps a session on the model it was
+    /// created with — verified: a session pinned to Haiku resumed as Haiku while
+    /// the configured default was Opus. So for a restored session the configured
+    /// default (<see cref="ResolveConfiguredModel"/>) is the wrong answer.
+    ///
+    /// Returns the model of the *last* assistant entry, so a mid-session model
+    /// switch is respected, or null if the transcript is missing or has no
+    /// assistant turns yet.
+    /// </summary>
+    public static string? ResolveSessionModel(string? sessionId, ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) return null;
+
+        try
+        {
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (string.IsNullOrEmpty(userProfile)) return null;
+
+            var projectsRoot = Path.Combine(userProfile, ".claude", "projects");
+            if (!Directory.Exists(projectsRoot)) return null;
+
+            // Transcripts live under a per-working-directory folder whose name is
+            // an encoded form of the path ("E:\Lingos" -> "E--Lingos"). Rather
+            // than reproduce that encoding — undocumented and liable to change —
+            // just find the file by session id.
+            var file = FirstOrDefault(Directory.EnumerateFiles(
+                projectsRoot, sessionId!.Trim() + ".jsonl", SearchOption.AllDirectories));
+            if (file is null)
+            {
+                logger?.LogDebug("[ModelResolver] No transcript found for session {SessionId}", sessionId);
+                return null;
+            }
+
+            string? lastModel = null;
+            // Streamed, with a cheap substring prefilter so we only pay for JSON
+            // parsing on assistant turns — transcripts reach many megabytes.
+            foreach (var line in File.ReadLines(file))
+            {
+                if (line.Length == 0) continue;
+                if (line.IndexOf("\"assistant\"", StringComparison.Ordinal) < 0) continue;
+
+                try
+                {
+                    using var doc = JsonDocument.Parse(line);
+                    var root = doc.RootElement;
+                    if (root.ValueKind != JsonValueKind.Object) continue;
+                    if (!root.TryGetProperty("type", out var t) || t.GetString() != "assistant") continue;
+                    if (!root.TryGetProperty("message", out var msg)) continue;
+                    if (!msg.TryGetProperty("model", out var m) || m.ValueKind != JsonValueKind.String) continue;
+
+                    var value = m.GetString();
+                    if (!string.IsNullOrWhiteSpace(value)) lastModel = value!.Trim();
+                }
+                catch (JsonException)
+                {
+                    // A torn final line (the CLI may be mid-write) — skip it.
+                }
+            }
+
+            logger?.LogDebug("[ModelResolver] Session {SessionId} last ran on {Model}", sessionId, lastModel);
+            return lastModel;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "[ModelResolver] Could not read transcript for session {SessionId}", sessionId);
+            return null;
+        }
+    }
+
+    private static string? FirstOrDefault(IEnumerable<string> items)
+    {
+        foreach (var item in items) return item;
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the configured model id/alias, or null when it can't be
+    /// determined (no setting anywhere, meaning the account default applies).
+    ///
+    /// This is only the right answer for a *new* session — see
+    /// <see cref="ResolveSessionModel"/> for restored ones.
+    /// Precedence follows Claude Code's documented order, highest first:
+    /// managed policy → env → project-local → project → user settings.
+    /// We never pass <c>--model</c>, so the CLI-flag tier is skipped.
+    /// </summary>
+    public static string? ResolveConfiguredModel(string? workingDirectory, ILogger? logger = null)
+    {
+        foreach (var path in CandidateSettingsPaths(workingDirectory))
+        {
+            // The env var tier sits between managed policy and project settings;
+            // CandidateSettingsPaths yields a null marker at that position.
+            if (path is null)
+            {
+                var fromEnv = Environment.GetEnvironmentVariable("ANTHROPIC_MODEL");
+                if (!string.IsNullOrWhiteSpace(fromEnv))
+                {
+                    logger?.LogDebug("[ModelResolver] Model from ANTHROPIC_MODEL: {Model}", fromEnv);
+                    return Interpret(fromEnv);
+                }
+                continue;
+            }
+
+            var model = ReadModelSetting(path, logger);
+            if (model is not null)
+            {
+                logger?.LogDebug("[ModelResolver] Model from {Path}: {Model}", path, model);
+                // A hit at this tier wins outright — including the literal
+                // "default", which the CLI's model picker writes to mean "use the
+                // account default". That must stop the search rather than fall
+                // through to a lower-precedence file that names a real model.
+                return Interpret(model);
+            }
+        }
+
+        logger?.LogDebug("[ModelResolver] No configured model found; account default applies");
+        return null;
+    }
+
+    private static IEnumerable<string?> CandidateSettingsPaths(string? workingDirectory)
+    {
+        // 1. Enterprise managed policy — overrides everything.
+        var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        if (!string.IsNullOrEmpty(programData))
+            yield return Path.Combine(programData, "ClaudeCode", "managed-settings.json");
+
+        // 2. Environment variable (signalled by the null marker).
+        yield return null;
+
+        // 3/4. Project settings, searched from the working directory upwards so a
+        // solution nested below the repo root still picks up the repo's .claude.
+        // Local overrides the shared file at each level, matching the CLI.
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            DirectoryInfo? dir = null;
+            try { dir = new DirectoryInfo(workingDirectory!); } catch { }
+
+            while (dir is not null && dir.Exists)
+            {
+                yield return Path.Combine(dir.FullName, ".claude", "settings.local.json");
+                yield return Path.Combine(dir.FullName, ".claude", "settings.json");
+                dir = dir.Parent;
+            }
+        }
+
+        // 5. User-level settings.
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(userProfile))
+            yield return Path.Combine(userProfile, ".claude", "settings.json");
+    }
+
+    private static string? ReadModelSetting(string path, ILogger? logger)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+
+            // Tolerate comments / trailing commas — hand-edited settings files
+            // often have them and the CLI accepts them.
+            var options = new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            };
+            using var doc = JsonDocument.Parse(File.ReadAllText(path), options);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+            if (!doc.RootElement.TryGetProperty("model", out var m)) return null;
+            if (m.ValueKind != JsonValueKind.String) return null;
+
+            var raw = m.GetString();
+            return string.IsNullOrWhiteSpace(raw) ? null : raw!.Trim();
+        }
+        catch (Exception ex)
+        {
+            // A malformed or unreadable settings file must never break the chat
+            // window — fall through to the next candidate.
+            logger?.LogDebug(ex, "[ModelResolver] Could not read {Path}", path);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Maps a winning setting value to what we should display. "default" means
+    /// "whatever the account default is" — we can't know that without an API
+    /// call, so report nothing rather than showing the literal word.
+    /// </summary>
+    private static string? Interpret(string? model)
+    {
+        if (string.IsNullOrWhiteSpace(model)) return null;
+        var trimmed = model!.Trim();
+        return trimmed.Equals("default", StringComparison.OrdinalIgnoreCase) ? null : trimmed;
+    }
+}

--- a/src/VsAgentic.Services/ClaudeCli/Permissions/IPermissionBroker.cs
+++ b/src/VsAgentic.Services/ClaudeCli/Permissions/IPermissionBroker.cs
@@ -31,6 +31,23 @@ public interface IPermissionBroker
     void Resolve(string requestId, PermissionDecision decision);
 
     /// <summary>
+    /// Auto-allow later requests matching <paramref name="request"/> for the
+    /// rest of the session, without surfacing a banner. No-op when the request
+    /// has no <see cref="PermissionRequest.SessionAllowKey"/>.
+    ///
+    /// This is extension-side state only: the CLI still sees an ordinary
+    /// "allow" on the wire, so nothing is persisted to the user's settings.
+    /// </summary>
+    void RememberAllow(PermissionRequest request);
+
+    /// <summary>
+    /// Drops every remembered allow. Called when the chat session changes and
+    /// when the CLI subprocess (re)starts — either makes the rules stale, and
+    /// the broker is a singleton that outlives both.
+    /// </summary>
+    void ClearRememberedAllows();
+
+    /// <summary>
     /// Denies every in-flight permission request. Used by the chat Stop button
     /// so the dispatcher loop can unblock when a permission banner is stuck.
     /// </summary>

--- a/src/VsAgentic.Services/ClaudeCli/Permissions/PermissionBroker.cs
+++ b/src/VsAgentic.Services/ClaudeCli/Permissions/PermissionBroker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -11,6 +12,14 @@ public sealed class PermissionBroker : IPermissionBroker
     private readonly ILogger<PermissionBroker> _logger;
     private readonly ConcurrentDictionary<string, TaskCompletionSource<PermissionDecision>> _pending = new();
 
+    /// <summary>
+    /// <see cref="PermissionRequest.SessionAllowKey"/> values the user chose to
+    /// stop being asked about. Used as a set; the value is ignored. Paths are
+    /// compared case-insensitively to match Windows filesystem semantics.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, byte> _rememberedAllows =
+        new(StringComparer.OrdinalIgnoreCase);
+
     public PermissionBroker(ILogger<PermissionBroker> logger)
     {
         _logger = logger;
@@ -20,6 +29,17 @@ public sealed class PermissionBroker : IPermissionBroker
 
     public Task<PermissionDecision> SubmitAsync(PermissionRequest request, CancellationToken cancellationToken)
     {
+        // Short-circuit before registering anything in _pending: the user
+        // already approved this file for the session, so no banner is raised
+        // and there is no pending entry for the UI to resolve.
+        if (request.SessionAllowKey is { } key && _rememberedAllows.ContainsKey(key))
+        {
+            _logger.LogInformation(
+                "[PermissionBroker] Auto-allowing {Tool} (remembered for this session)",
+                request.ToolName);
+            return Task.FromResult(PermissionDecision.Allow(RawInputJson(request)));
+        }
+
         var tcs = new TaskCompletionSource<PermissionDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
         if (!_pending.TryAdd(request.Id, tcs))
         {
@@ -59,6 +79,30 @@ public sealed class PermissionBroker : IPermissionBroker
             _logger.LogWarning("[PermissionBroker] Resolve for unknown request id {Id}", requestId);
         }
     }
+
+    public void RememberAllow(PermissionRequest request)
+    {
+        if (request.SessionAllowKey is not { } key) return;
+        if (_rememberedAllows.TryAdd(key, 0))
+        {
+            _logger.LogInformation(
+                "[PermissionBroker] Remembering allow for {Tool} for the rest of the session",
+                request.ToolName);
+        }
+    }
+
+    public void ClearRememberedAllows()
+    {
+        if (_rememberedAllows.IsEmpty) return;
+        var count = _rememberedAllows.Count;
+        _rememberedAllows.Clear();
+        _logger.LogInformation("[PermissionBroker] Cleared {Count} remembered allow(s)", count);
+    }
+
+    private static string RawInputJson(PermissionRequest request) =>
+        request.Input.ValueKind == JsonValueKind.Undefined
+            ? "{}"
+            : request.Input.GetRawText();
 
     public void CancelAllPending()
     {

--- a/src/VsAgentic.Services/ClaudeCli/Permissions/PermissionRequest.cs
+++ b/src/VsAgentic.Services/ClaudeCli/Permissions/PermissionRequest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Text.Json;
 
 namespace VsAgentic.Services.ClaudeCli.Permissions;
@@ -12,11 +14,43 @@ public sealed class PermissionRequest
     public string ToolName { get; }
     public JsonElement Input { get; }
 
+    /// <summary>
+    /// Identity of this request for "allow for the rest of the session"
+    /// purposes, or <c>null</c> when the request has no stable identity worth
+    /// remembering.
+    ///
+    /// Only tools whose input carries a <c>file_path</c> get a key — Edit,
+    /// Write, NotebookEdit and friends. Bash deliberately does not: its
+    /// <c>command</c> differs on every call, so the only rule we could form
+    /// would be "allow all Bash", which is far broader than the user agreed to.
+    /// </summary>
+    public string? SessionAllowKey { get; }
+
     public PermissionRequest(string id, string toolName, JsonElement input)
     {
         Id = id;
         ToolName = toolName;
         Input = input;
+        SessionAllowKey = BuildSessionAllowKey(toolName, input);
+    }
+
+    private static string? BuildSessionAllowKey(string toolName, JsonElement input)
+    {
+        if (string.IsNullOrEmpty(toolName)) return null;
+        if (input.ValueKind != JsonValueKind.Object) return null;
+        if (!input.TryGetProperty("file_path", out var fp)) return null;
+        if (fp.ValueKind != JsonValueKind.String) return null;
+
+        var path = fp.GetString();
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        // Normalise so "src\a.cs" and "src/a.cs" collapse to one rule. An
+        // unnormalisable path still gets a key — worst case the user is asked
+        // once more for a spelling we couldn't canonicalise.
+        try { path = Path.GetFullPath(path); }
+        catch (Exception) { }
+
+        return toolName + "\0" + path;
     }
 }
 

--- a/src/VsAgentic.UI/ViewModels/Banners/PermissionBannerViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/Banners/PermissionBannerViewModel.cs
@@ -10,11 +10,19 @@ public partial class PermissionBannerViewModel : ObservableObject, IBannerViewMo
 {
     private readonly PermissionRequest _request;
     private readonly Action<PermissionDecision> _onResolved;
+    private readonly Action<PermissionRequest>? _onRememberAllow;
 
     public string ToolName => _request.ToolName;
     public string Header => $"Claude wants to use {_request.ToolName}";
     public string BodyText { get; }
     public bool HasBodyText => !string.IsNullOrEmpty(BodyText);
+
+    /// <summary>Shows the "Allow for session" button only for requests that
+    /// have a stable identity to remember — see
+    /// <see cref="PermissionRequest.SessionAllowKey"/>. Bash prompts don't, so
+    /// the button would silently do nothing there.</summary>
+    public bool CanAllowForSession =>
+        _onRememberAllow is not null && _request.SessionAllowKey is not null;
 
     /// <summary>Toggles the banner between the initial Allow/Deny/Other... row
     /// and the alternative-instructions input row.</summary>
@@ -26,10 +34,14 @@ public partial class PermissionBannerViewModel : ObservableObject, IBannerViewMo
     [ObservableProperty]
     private string _alternativeText = "";
 
-    public PermissionBannerViewModel(PermissionRequest request, Action<PermissionDecision> onResolved)
+    public PermissionBannerViewModel(
+        PermissionRequest request,
+        Action<PermissionDecision> onResolved,
+        Action<PermissionRequest>? onRememberAllow = null)
     {
         _request = request;
         _onResolved = onResolved;
+        _onRememberAllow = onRememberAllow;
         BodyText = FormatBody(request);
     }
 
@@ -48,6 +60,17 @@ public partial class PermissionBannerViewModel : ObservableObject, IBannerViewMo
             ? "{}"
             : _request.Input.GetRawText();
         _onResolved(PermissionDecision.Allow(inputJson));
+    }
+
+    /// <summary>Allows this call and suppresses the banner for later calls
+    /// against the same tool and file until the session ends. The wire-level
+    /// decision is an ordinary allow — the "remember" half is extension-side
+    /// state held by the broker, so nothing is written to the user's settings.</summary>
+    [RelayCommand]
+    private void AllowForSession()
+    {
+        _onRememberAllow?.Invoke(_request);
+        Allow();
     }
 
     [RelayCommand]

--- a/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using VsAgentic.Services.Abstractions;
+using VsAgentic.Services.ClaudeCli;
 using VsAgentic.Services.ClaudeCli.Permissions;
 using VsAgentic.Services.ClaudeCli.Questions;
 using VsAgentic.Services.Configuration;
@@ -39,14 +40,24 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
     private string _sessionTitle = "New Session";
 
     // Realtime activity indicator: a braille spinner prefix while the AI is
-    // working, a steady "? " prefix while awaiting user input (permission /
+    // working, a blinking hand while awaiting user input (permission /
     // question banner), and no prefix while idle. Host bindings (e.g. the VS
     // tool window caption) should use DisplayTitle; SessionTitle stays plain
     // for the session list entry so the sidebar doesn't flicker.
     private static readonly string SpinnerFrames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
-    private const string AwaitingPrefix = "? ";
+    // Two hand glyphs rather than a hand alternating with blank: the caption is
+    // a plain string with no way to hide a glyph, so anything but an equal-width
+    // pair shifts the title text on every frame. The trailing U+FE0F on the
+    // raised hand forces emoji presentation — its text-presentation fallback is
+    // narrower, which would reintroduce the shift.
+    private static readonly string[] AwaitingFrames = { "👋 ", "✋️ " };
+    // The timer runs at spinner speed, which would strobe the hand, so the hand
+    // advances only every Nth tick (~0.5s). The tick counter wraps at the LCM of
+    // both cycles (10 spinner frames, 2 x 4 hand ticks) so neither jumps on rollover.
+    private const int AwaitingTicksPerFrame = 4;
+    private const int AnimationTickCycle = 40;
     private int _pendingUserPrompts;
-    private int _spinnerFrame;
+    private int _animationTick;
     private System.Windows.Threading.DispatcherTimer? _activityTimer;
 
     [ObservableProperty]
@@ -63,7 +74,11 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
 
     private void UpdateActivityIndicator()
     {
-        if (Activity == SessionActivity.Busy)
+        // Activity is computed, so it has to be notified by hand for the
+        // status-bar triggers in ChatSessionControl.xaml to see the change.
+        OnPropertyChanged(nameof(Activity));
+
+        if (Activity is SessionActivity.Busy or SessionActivity.AwaitingUser)
         {
             EnsureActivityTimer();
             if (!_activityTimer!.IsEnabled) _activityTimer.Start();
@@ -71,6 +86,7 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
         else
         {
             _activityTimer?.Stop();
+            _animationTick = 0;
         }
         UpdateDisplayTitle();
     }
@@ -87,7 +103,7 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
         };
         _activityTimer.Tick += (_, _) =>
         {
-            _spinnerFrame = (_spinnerFrame + 1) % SpinnerFrames.Length;
+            _animationTick = (_animationTick + 1) % AnimationTickCycle;
             UpdateDisplayTitle();
         };
     }
@@ -96,8 +112,9 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
     {
         var prefix = Activity switch
         {
-            SessionActivity.Busy => SpinnerFrames[_spinnerFrame] + " ",
-            SessionActivity.AwaitingUser => AwaitingPrefix,
+            SessionActivity.Busy => SpinnerFrames[_animationTick % SpinnerFrames.Length] + " ",
+            SessionActivity.AwaitingUser =>
+                AwaitingFrames[(_animationTick / AwaitingTicksPerFrame) % AwaitingFrames.Length],
             _ => ""
         };
         DisplayTitle = prefix + SessionTitle;
@@ -174,7 +191,120 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             _questionBroker.QuestionRequested += OnQuestionBrokerRequested;
 
         chatService.LoginRequired += OnChatServiceLoginRequired;
+        chatService.ModelChanged += OnChatServiceModelChanged;
+        StatusInfo = FormatModelName(chatService.CurrentModel);
+        StartModelProbe();
     }
+
+    private void OnChatServiceModelChanged(string? model)
+        => Dispatch(() => StatusInfo = FormatModelName(model));
+
+    private int _modelProbeGeneration;
+
+    /// <summary>
+    /// Fills the status strip with this session's model at window load, since the
+    /// CLI's authoritative <c>system/init</c> value doesn't arrive until the first
+    /// message is sent.
+    ///
+    /// Which source is correct depends on whether the session is new: <c>--resume</c>
+    /// keeps a session on the model it was created with, so the configured default
+    /// is only valid for a session that hasn't run yet. Called again after history
+    /// is restored, when the session id becomes known.
+    ///
+    /// Runs off the UI thread (it reads settings files and possibly a transcript).
+    /// </summary>
+    private void StartModelProbe()
+    {
+        var generation = Interlocked.Increment(ref _modelProbeGeneration);
+
+        Task.Run(() =>
+        {
+            string? probed;
+            try
+            {
+                // A known session id means this session has already run, so ask
+                // what it actually ran on. Only fall back to the configured
+                // default when there's no transcript to consult — without one the
+                // CLI can't carry a model forward either.
+                var sessionId = _chatService?.CliSessionId;
+                probed = ClaudeModelResolver.ResolveSessionModel(sessionId, _logger)
+                    ?? ClaudeModelResolver.ResolveConfiguredModel(WorkingDirectory, _logger);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "[ChatSession] Model probe failed");
+                return;
+            }
+
+            if (probed is null) return;
+
+            Dispatch(() =>
+            {
+                // Don't overwrite a better answer: the CLI's real value, or a
+                // later probe that had the session id this one lacked.
+                if (_chatService?.CurrentModel is not null) return;
+                if (Volatile.Read(ref _modelProbeGeneration) != generation) return;
+                StatusInfo = FormatModelName(probed);
+            });
+        });
+    }
+
+    /// <summary>
+    /// Turns the CLI's model id into something short enough for the status strip:
+    /// "claude-opus-5" → "Opus 5", "claude-3-5-haiku-20241022" → "Haiku 3.5".
+    /// Unrecognized ids are shown verbatim minus the "claude-" prefix, so a new
+    /// model still displays something sensible without a code change.
+    /// </summary>
+    internal static string FormatModelName(string? model)
+    {
+        if (string.IsNullOrWhiteSpace(model)) return "";
+
+        var id = model!.Trim();
+
+        // "claude-fable-5[1m]" — the 1M-context variant. Strip the marker so the
+        // version parsing below works, and re-attach it to the display name.
+        var suffix = "";
+        var bracket = id.IndexOf('[');
+        if (bracket > 0 && id.EndsWith("]", StringComparison.Ordinal))
+        {
+            suffix = " " + id.Substring(bracket + 1, id.Length - bracket - 2).ToUpperInvariant();
+            id = id.Substring(0, bracket);
+        }
+
+        if (id.StartsWith("claude-", StringComparison.OrdinalIgnoreCase))
+            id = id.Substring("claude-".Length);
+
+        // Drop a trailing yyyyMMdd date stamp ("haiku-4-5-20251001" → "haiku-4-5").
+        var parts = id.Split('-').ToList();
+        var last = parts[parts.Count - 1];
+        if (parts.Count > 1 && last.Length == 8 && last.All(char.IsDigit))
+            parts.RemoveAt(parts.Count - 1);
+
+        // Family name plus whatever version segments surround it, in either the
+        // "opus-5" or legacy "3-5-haiku" ordering.
+        var familyIndex = parts.FindIndex(p =>
+            p.Equals("opus", StringComparison.OrdinalIgnoreCase) ||
+            p.Equals("sonnet", StringComparison.OrdinalIgnoreCase) ||
+            p.Equals("haiku", StringComparison.OrdinalIgnoreCase) ||
+            p.Equals("fable", StringComparison.OrdinalIgnoreCase));
+        if (familyIndex < 0)
+            return "Model: " + model;
+
+        var family = parts[familyIndex];
+        family = char.ToUpperInvariant(family[0]) + family.Substring(1).ToLowerInvariant();
+
+        var version = string.Join(".", parts.Where((p, i) => i != familyIndex && p.All(char.IsDigit)));
+        return string.IsNullOrEmpty(version)
+            ? "Model: " + family + suffix
+            : "Model: " + family + " " + version + suffix;
+    }
+
+    /// <summary>
+    /// Text shown in the status strip beside the @-mention button. Currently the
+    /// active model; plan/usage details are intended to join it here.
+    /// </summary>
+    [ObservableProperty]
+    private string _statusInfo = "";
 
     private void OnChatServiceLoginRequired(string? errorMessage)
     {
@@ -208,7 +338,8 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
                         UpdateActivityIndicator();
                     });
                     _permissionBroker?.Resolve(request.Id, decision);
-                });
+                },
+                onRememberAllow: remembered => _permissionBroker?.RememberAllow(remembered));
             }
             catch (Exception ex)
             {
@@ -271,6 +402,12 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
 
     private void SetPersistence(ISessionStore store, string folder, int id)
     {
+        // The broker is a singleton spanning the whole extension lifetime, so
+        // "allow for the rest of the session" grants have to be dropped
+        // explicitly when we move to a different chat session.
+        if (_sessionId != id)
+            _permissionBroker?.ClearRememberedAllows();
+
         _sessionStore = store;
         _folderPath = folder;
         _sessionId = id;
@@ -332,6 +469,12 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             if (historyJson is not null && _chatService is not null)
             {
                 _chatService.RestoreHistory(historyJson);
+
+                // The session id is only known now. Re-probe so a restored session
+                // shows the model it actually ran on rather than the current
+                // default — unless RestoreHistory already supplied one.
+                if (_chatService.CurrentModel is null)
+                    StartModelProbe();
             }
         }
         catch
@@ -544,7 +687,12 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
 
     private void OnStepUpdated(OutputItem item)
     {
-        if (string.IsNullOrEmpty(item.Delta))
+        var isThinking = item.ToolName == "Thinking";
+
+        // Thinking updates are driven by the CLI's thinking_tokens events, which carry
+        // a live title but no text (the thinking block itself comes back redacted), so
+        // they must not be gated on Delta.
+        if (string.IsNullOrEmpty(item.Delta) && !isThinking)
             return;
 
         Dispatch(() =>
@@ -553,13 +701,14 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             {
                 vm.Content += item.Delta;
 
-                if (item.ToolName == "Thinking")
+                if (isThinking)
                 {
                     vm.ExpanderTitle = item.Title;
                     MessageStatusUpdated?.Invoke(item.Id, vm.Status, item.Title);
                 }
 
-                MessageContentUpdated?.Invoke(item.Id, vm.Content);
+                if (!string.IsNullOrEmpty(item.Delta))
+                    MessageContentUpdated?.Invoke(item.Id, vm.Content);
 
                 var index = Items.IndexOf(vm);
                 if (index >= 0 && index < Items.Count - 1)
@@ -708,6 +857,11 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         try { _activityTimer?.Stop(); } catch { }
+        if (_chatService is not null)
+        {
+            _chatService.LoginRequired -= OnChatServiceLoginRequired;
+            _chatService.ModelChanged -= OnChatServiceModelChanged;
+        }
         try { (_chatService as IDisposable)?.Dispose(); } catch { }
         try { _serviceScope?.Dispose(); } catch { }
     }

--- a/src/VsAgentic.VSExtension/ToolWindows/Banners/PermissionBannerControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/Banners/PermissionBannerControl.xaml
@@ -39,6 +39,11 @@
                 <Button Content="Allow"
                         Style="{StaticResource PrimaryButtonStyle}"
                         Command="{Binding AllowCommand}"/>
+                <Button Content="Allow for session"
+                        Style="{StaticResource PrimaryButtonStyle}"
+                        Command="{Binding AllowForSessionCommand}"
+                        Visibility="{Binding CanAllowForSession, Converter={StaticResource BoolToVis}}"
+                        ToolTip="Allow this tool for this file without asking again until the session ends"/>
                 <Button Content="Deny"
                         Style="{StaticResource DangerButtonStyle}"
                         Command="{Binding DenyCommand}"/>

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
@@ -11,6 +11,17 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
 
+        <!-- Flashes the status bar background while waiting for input. To-only
+             animation with AutoReverse, so the themed base colour never has to
+             be restated here: it animates from whatever the brush currently is
+             and back. Keyframes can't carry a DynamicResource anyway (a
+             Storyboard is a Freezable), and VsBrushes keys resolve to a Brush,
+             not the Color a colour keyframe needs. -->
+        <Storyboard x:Key="FlashStoryboard" RepeatBehavior="Forever" AutoReverse="True">
+            <ColorAnimation Storyboard.TargetProperty="Background.Color"
+                            To="#66808080" Duration="0:0:0.75"/>
+        </Storyboard>
+
         <!-- Banner DataTemplates: ContentControl below picks the right view by VM type. -->
         <DataTemplate DataType="{x:Type bvm:PermissionBannerViewModel}">
             <bv:PermissionBannerControl/>
@@ -236,6 +247,25 @@
                         <Border Grid.Row="1"
                                 BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
                                 BorderThickness="0,1,0,0">
+                            <!-- A local brush, not the shared VsBrushes one: the themed
+                                 brushes are frozen and can't be animated. -->
+                            <Border.Background>
+                                <SolidColorBrush Color="{DynamicResource {x:Static vs:VsColors.ComboBoxBackgroundKey}}"/>
+                            </Border.Background>
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Activity}" Value="AwaitingUser">
+                                            <DataTrigger.EnterActions>
+                                                <BeginStoryboard x:Name="FlashBegin" Storyboard="{StaticResource FlashStoryboard}"/>
+                                            </DataTrigger.EnterActions>
+                                            <DataTrigger.ExitActions>
+                                                <StopStoryboard BeginStoryboardName="FlashBegin"/>
+                                            </DataTrigger.ExitActions>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
@@ -255,9 +285,13 @@
                                                Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
                                 </Button>
 
-                                <!-- Status info area (reserved for future) -->
+                                <!-- Status info area: active model, and (later)
+                                     plan usage. Populated from the CLI's
+                                     system/init event via StatusInfo. -->
                                 <TextBlock Grid.Column="1"
                                            x:Name="StatusInfoText"
+                                           Text="{Binding StatusInfo}"
+                                           ToolTip="{Binding StatusInfo}"
                                            VerticalAlignment="Center"
                                            Margin="10,0"
                                            FontSize="11"
@@ -286,14 +320,38 @@
             </Grid>
         </Border>
 
-        <!-- Busy indicator -->
+        <!-- Status indicator: "Thinking..." while the turn runs, "Waiting for
+             input…" while a permission / question banner needs an answer, and
+             hidden when idle. -->
         <Border DockPanel.Dock="Bottom"
                 Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}"
-                Padding="16,4"
-                Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
-            <TextBlock Text="Thinking..."
-                       Foreground="{DynamicResource {x:Static vs:VsBrushes.GrayTextKey}}"
-                       FontSize="12" FontStyle="Italic"/>
+                Padding="16,4">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Activity}" Value="Busy">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Activity}" Value="AwaitingUser">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <TextBlock Foreground="{DynamicResource {x:Static vs:VsBrushes.GrayTextKey}}"
+                       FontSize="12" FontStyle="Italic">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Text" Value="Thinking..."/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Activity}" Value="AwaitingUser">
+                                <Setter Property="Text" Value="Waiting for input…"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
         </Border>
 
         <!-- Banner host: permission / question / login banner. The DataTemplates

--- a/src/VsAgentic.VSExtension/VsAgentic.VSExtension.csproj
+++ b/src/VsAgentic.VSExtension/VsAgentic.VSExtension.csproj
@@ -10,6 +10,27 @@
     <VssdkCompatibleExtension>true</VssdkCompatibleExtension>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
 
+    <!--
+      F5 deployment to the Experimental Instance.
+
+      Microsoft.VisualStudio.Extensibility.Build.targets defaults
+      DeployExtension to FALSE, and it is imported after
+      Microsoft.VsSDK.targets (which defaults it to true) — so in a hybrid
+      VSSDK + VisualStudio.Extensibility extension like this one the
+      out-of-proc default wins and DeployVsixExtensionFiles silently never
+      runs. The result is that F5 builds the VSIX and then launches a clean
+      Experimental Instance with nothing installed in it.
+
+      Setting it here in the project body beats both package defaults
+      (their conditions only fire when the property is still empty).
+
+      Scoped to full-framework MSBuild on purpose: Microsoft.VsSDK.targets
+      hard-errors with "VSIX deployment is not supported with 'dotnet build'"
+      when MSBuildRuntimeType is Core, which would break the
+      `dotnet build src/VsAgentic.slnx` used by CI and by the docs.
+    -->
+    <DeployExtension Condition="'$(MSBuildRuntimeType)' != 'Core'">true</DeployExtension>
+
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
@@ -94,5 +115,30 @@
   <ItemGroup>
     <None Include="source.extension.vsixmanifest" SubType="Designer" />
   </ItemGroup>
+
+  <!--
+    Force the intermediate manifest to be regenerated when the source one changes.
+
+    DetokenizeVsixManifestSource (Microsoft.VSSDK.BuildTools 17.14.2120) writes
+    $(IntermediateOutputPath)extension.vsixmanifest only when that file does not
+    already exist — it reports the write in FileWrites either way, so the build
+    log gives no hint. Every edit to source.extension.vsixmanifest is therefore
+    silently ignored on an incremental build: the version, DisplayName,
+    Description, Prerequisites and Assets are all frozen at whatever they were
+    when obj was last clean, and the packed .vsix keeps carrying the stale copy.
+
+    Version is the one that bites hardest, because VSIXInstaller keys on it —
+    a bumped manifest produces a .vsix still stamped with the old version, which
+    then silently fails to install over itself.
+
+    Inputs/Outputs make this a no-op once the intermediate is current, so the
+    delete only happens on the builds that actually need it.
+  -->
+  <Target Name="ForceRefreshIntermediateVsixManifest"
+          BeforeTargets="DetokenizeVsixManifestFile"
+          Inputs="source.extension.vsixmanifest"
+          Outputs="$(IntermediateOutputPath)extension.vsixmanifest">
+    <Delete Files="$(IntermediateOutputPath)extension.vsixmanifest" />
+  </Target>
 
 </Project>

--- a/src/VsAgentic.VSExtension/source.extension.vsixmanifest
+++ b/src/VsAgentic.VSExtension/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="VsAgentic.VSExtension.c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
-              Version="3.4.4"
+              Version="3.4.6"
               Language="en-US"
               Publisher="Adolfo Marinucci" />
     <DisplayName>VsAgentic</DisplayName>

--- a/src/VsAgentic.slnx
+++ b/src/VsAgentic.slnx
@@ -2,6 +2,11 @@
   <Folder Name="/Solution Items/">
     <File Path="../.github/workflows/publish-vsix.yml" />
     <File Path="../README.md" />
+    <File Path="../CONTRIBUTING.md" />
+    <File Path="CLAUDE.md" />
+  </Folder>
+  <Folder Name="/scripts/">
+    <File Path="../scripts/install-local.ps1" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="VsAgentic.Services/VsAgentic.Services.csproj" />


### PR DESCRIPTION
@adospace - hope you don't mind, I went a bit crazy with adding to your extension. You've done a great job so far. With help from Claude it wasn't difficult to add a few things. 

Please comment on the PR and I will update. I can withdraw the PR and make those changes and re-submit (maybe to a different branch?) until you are happy. If you want a few PRs with each change in separately I could do that as well. 
Most of the comments are Claude generated, I’ve sense checked them - but PLEASE disagree with the rubbish ones. It didn’t like what appeared to be stale projects - which I assume you will work on at some point. 

### Functional changes to the UI:

- **Allow for this session** - when editing files it now displays an additional button of "Allow for this session", so that multiple edits don't ask each time
- **Model in the status bar** - shows the model in use by that session. For existing sessions it picks it you from the transcript (see ClaudeModelResolver)
- **Waiting for user visuals** - In a multi window environment hard to see when the chat window is waiting for user input. So, I added:
  - Animated waving had in tab title (same position as the thinking animation)
  - Slow flashing status bar
- **Thinking time and tokens** - displays in the chat window (next to the Thinking...) the amount of elapsed seconds and token usage 

### Main solution changes

- **CONTRIBUTING.md** - Created some instructions on how to build and test locally. Do you actually want that included, or would you prefer that people don't actually make PRs against your repo? Maybe they just create an issue with a link to their branch?
- **VSIX local install script** - Script to run which uninstalls VsAgentic and installs the version from the branch being worked on. It allowed me to use it in my own context, and iron out wrinkles.

### Next steps
Before you accept the PR you might want me to add an option for people to turn off the waiting animations. I've also only tested on a subscription, not sure if there are any complications for Claude API only users will.
 
The next items I want to add are:

- Mid session model changes - e.g. start on Sonnet and move up to Opus
- Right click menu to start session based on current line of code
- Unit tests 

 Any preferences on how I submit those? 