### PR TITLE
Deploy the VSIX into the experimental hive on IDE builds

### DIFF
--- a/src/VsAgentic.VSExtension/VsAgentic.VSExtension.csproj
+++ b/src/VsAgentic.VSExtension/VsAgentic.VSExtension.csproj
@@ -10,6 +10,27 @@
     <VssdkCompatibleExtension>true</VssdkCompatibleExtension>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
 
+    <!--
+      Microsoft.VisualStudio.Extensibility.Build.targets defaults
+      DeployExtension to false, which wins over the VSSDK default of true
+      because it is evaluated first. FindExistingDeploymentPath and
+      DeployVsixExtensionFiles are both gated on DeployExtension=='true', so
+      the build silently produces the .vsix without ever copying it into the
+      experimental hive — F5 then lands in a Visual Studio that has no
+      VsAgentic in it, with nothing in the build output to explain why.
+
+      Turn deployment back on for builds started from the IDE only.
+      Command-line builds — including `dotnet build` in publish-vsix.yml —
+      leave BuildingInsideVisualStudio unset and keep the packaging-only
+      behaviour, which is what a build agent with no experimental hive wants.
+
+      Note that the debug profile has to be the "Executable" one that launches
+      devenv.exe /RootSuffix Exp (see Properties\launchSettings.json). A VSIX
+      project is a class library, so VS refuses to start it directly and the
+      "Project" profile cannot be used.
+    -->
+    <DeployExtension Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</DeployExtension>
+
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>


### PR DESCRIPTION
Fixes #16

### Change

One property in `VsAgentic.VSExtension.csproj`:

```xml
<DeployExtension Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</DeployExtension>
```

Setting it in the project body means it is already non-empty when `Microsoft.VisualStudio.Extensibility.Build.targets` tries to default it to `false`, so its `Condition="'$(DeployExtension)' == ''"` no longer applies and the two deployment targets run.

The condition limits this to builds started from the IDE. Command line builds leave `BuildingInsideVisualStudio` unset and keep the current packaging-only behaviour, so `dotnet build` in `publish-vsix.yml` is unaffected — a build agent has no experimental hive to deploy to.

### Verified

Tested with the local `.csproj.user` temporarily removed, so it could not mask the result:

| Build | Result |
|---|---|
| `MSBuild` from the command line | deployment targets skipped, unchanged |
| `MSBuild /p:BuildingInsideVisualStudio=true` | `VsixDeploymentPath = ...\18.0_<instanceid>Exp\Extensions\<publisher>\VsAgentic\3.4.4\` |

After the change, F5 builds and deploys in one step and the extension appears in the experimental instance.

### Note

The comment in the csproj also records that the debug profile has to be the "Executable" one launching `devenv.exe /RootSuffix Exp`. A VSIX project is a class library, so Visual Studio refuses to start it directly and the "Project" profile fails with *"A project with an Output Type of Class Library cannot be started directly"*. That cost me some time, so it seemed worth writing down next to the property.

No version bump is included — that seemed like your call, especially if more than one PR lands.
