### PR TITLE
Visually separate user prompts in the chat

### DIFF
--- a/src/VsAgentic.UI/Assets/chat-template.html
+++ b/src/VsAgentic.UI/Assets/chat-template.html
@@ -15,7 +15,10 @@
     --success: #4ec9b0;
     --error: #f44747;
     --info: #808080;
-    --user-bg: #252526;
+    --prompt-bg: #202830;
+    --prompt-border: #3d4b59;
+    --prompt-accent: #569cd6;
+    --thinking-bg: #252526;
     --code-bg: #3c3c3c;
     --pre-bg: #1e1e1e;
 }
@@ -124,16 +127,20 @@ html, body {
 .msg { margin: 2px 12px; }
 
 .msg-user {
-    background: var(--user-bg);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 8px;
+    background: var(--prompt-bg);
+    border: 1px solid var(--prompt-border);
+    border-left: 4px solid var(--prompt-accent);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-top: 14px;
+    margin-bottom: 12px;
 }
 .msg-user .msg-label {
-    font-weight: 600;
-    font-size: 11px;
-    margin-bottom: 2px;
-    color: var(--accent);
+    font-weight: 700;
+    font-size: 10px;
+    letter-spacing: 0.6px;
+    margin-bottom: 6px;
+    color: var(--prompt-accent);
 }
 
 .msg-assistant {
@@ -243,7 +250,7 @@ html, body {
 }
 .thinking-content {
     display: none;
-    background: var(--user-bg);
+    background: var(--thinking-bg);
     border-radius: 4px;
     padding: 10px 8px;
     margin: 4px 0 4px 18px;
@@ -265,7 +272,7 @@ html, body {
     left: 0;
     right: 0;
     height: 30px;
-    background: linear-gradient(transparent, var(--user-bg));
+    background: linear-gradient(transparent, var(--thinking-bg));
 }
 
 /* Streaming indicator */
@@ -470,7 +477,7 @@ function addMessage(id, type, dataJson) {
         div.classList.add('msg-user');
         var label = document.createElement('div');
         label.className = 'msg-label';
-        label.textContent = 'You';
+        label.textContent = 'YOU';
         var content = document.createElement('div');
         content.className = 'md-content msg-content';
         content.innerHTML = renderUserMd(data.Content || '');

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
@@ -91,9 +91,18 @@ public partial class ChatSessionControl : UserControl
         // highlight, which on Win11 is often violet/purple and clashes with
         // the dark/light VS theme.
         Map("--accent", EnvironmentColors.PanelHyperlinkColorKey);
-        Map("--user-bg", EnvironmentColors.CommandBarGradientBeginColorKey);
         Map("--code-bg", EnvironmentColors.ToolWindowContentGridColorKey);
         Map("--pre-bg", EnvironmentColors.ToolWindowBackgroundColorKey);
+        Map("--thinking-bg", EnvironmentColors.CommandBarGradientBeginColorKey);
+
+        var toolWindowBackground = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
+        var promptAccent = VSColorTheme.GetThemedColor(EnvironmentColors.PanelHyperlinkColorKey);
+        var promptBorderBase = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBorderColorKey);
+        var promptBgBlend = RelativeLuminance(toolWindowBackground) >= 0.5 ? 0.08 : 0.12;
+
+        colors["--prompt-bg"] = ToCssHex(Blend(toolWindowBackground, promptAccent, promptBgBlend));
+        colors["--prompt-border"] = ToCssHex(Blend(promptBorderBase, promptAccent, 0.35));
+        colors["--prompt-accent"] = ToCssHex(promptAccent);
 
         // Scrollbar: derive from gray/muted text for subtle appearance
         var gray = VSColorTheme.GetThemedColor(EnvironmentColors.ScrollBarThumbBackgroundColorKey);
@@ -103,6 +112,39 @@ public partial class ChatSessionControl : UserControl
 
         _ = ChatWebView.SetThemeColorsAsync(colors);
     }
+
+    private static System.Drawing.Color Blend(System.Drawing.Color from, System.Drawing.Color to, double amount)
+    {
+        amount = Math.Max(0, Math.Min(1, amount));
+
+        byte BlendChannel(byte fromChannel, byte toChannel) =>
+            (byte)Math.Round(fromChannel + ((toChannel - fromChannel) * amount));
+
+        return System.Drawing.Color.FromArgb(
+            BlendChannel(from.R, to.R),
+            BlendChannel(from.G, to.G),
+            BlendChannel(from.B, to.B));
+    }
+
+    private static double RelativeLuminance(System.Drawing.Color color)
+    {
+        var r = ToLinear(color.R);
+        var g = ToLinear(color.G);
+        var b = ToLinear(color.B);
+
+        return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
+    }
+
+    private static double ToLinear(byte channel)
+    {
+        var c = channel / 255.0;
+        return c <= 0.04045
+            ? c / 12.92
+            : Math.Pow((c + 0.055) / 1.055, 2.4);
+    }
+
+    private static string ToCssHex(System.Drawing.Color color) =>
+        $"#{color.R:X2}{color.G:X2}{color.B:X2}";
 
     private void InputTextBox_KeyDown(object sender, KeyEventArgs e)
     {


### PR DESCRIPTION
Fixes #20

Screenshots for both themes, before and after, are in the issue.

### Change

**`chat-template.html`** — `.msg-user` gets a 4px accent bar on the left, a tinted background, a larger corner radius and more vertical margin, so a prompt reads as a block rather than another paragraph. The label goes uppercase with letter spacing. Three new variables carry the colours:

```css
--prompt-bg
--prompt-border
--prompt-accent
```

The old `--user-bg` was doing double duty for the prompt block and for the collapsed thinking section. It is now `--thinking-bg`, used only by the latter, so the two can be styled independently.

**`ChatSessionControl.xaml.cs`** — the three new variables are computed from the current theme rather than hard-coded:

```csharp
var promptBgBlend = RelativeLuminance(toolWindowBackground) >= 0.5 ? 0.08 : 0.12;
colors["--prompt-bg"]     = ToCssHex(Blend(toolWindowBackground, promptAccent, promptBgBlend));
colors["--prompt-border"] = ToCssHex(Blend(promptBorderBase, promptAccent, 0.35));
colors["--prompt-accent"] = ToCssHex(promptAccent);
```

`Blend` is a plain linear mix of two colours. `RelativeLuminance` is the sRGB luminance from WCAG, used only to decide how strong the tint should be: light themes get a lighter mix so the block does not look muddy, dark themes get a stronger one so it does not disappear.

The accent comes from `EnvironmentColors.PanelHyperlinkColorKey`, which the file already used for `--accent`, so the block picks up whatever accent the active theme defines instead of introducing a new colour.

### Verified

Same session rendered in Dark and Light, switching themes at runtime through `VSColorTheme.ThemeChanged`, which the control already subscribes to. Both branches of the luminance check are exercised that way.

### Notes

This is a visual change, so treat the specifics as a starting point. The accent bar width, the uppercase label and the extra margin are each independent — say the word and I will tone any of them down or drop them.

No version bump included, same as the other two PRs.
