### PR TITLE
Allow pasting an image into the chat

### DIFF
--- a/src/VsAgentic.Services/Abstractions/ChatImageAttachment.cs
+++ b/src/VsAgentic.Services/Abstractions/ChatImageAttachment.cs
@@ -1,0 +1,49 @@
+namespace VsAgentic.Services.Abstractions;
+
+/// <summary>
+/// An image travelling with a user message. The CLI accepts these inline as
+/// base64 content blocks over stream-json stdin, so nothing has to be written
+/// to the project first.
+/// </summary>
+public sealed class ChatImageAttachment
+{
+    /// <summary>Raw encoded bytes, already in <see cref="MediaType"/> format.</summary>
+    public byte[] Data { get; }
+
+    /// <summary>One of the media types the API accepts: PNG, JPEG, GIF or WebP.</summary>
+    public string MediaType { get; }
+
+    /// <summary>
+    /// File name used when the attachment is persisted next to its session.
+    /// Empty until the store assigns one.
+    /// </summary>
+    public string FileName { get; set; } = "";
+
+    public ChatImageAttachment(byte[] data, string mediaType)
+    {
+        Data = data ?? throw new ArgumentNullException(nameof(data));
+        MediaType = string.IsNullOrWhiteSpace(mediaType)
+            ? throw new ArgumentException("Media type is required.", nameof(mediaType))
+            : mediaType;
+    }
+
+    /// <summary>Media types the Claude API accepts for image blocks.</summary>
+    public static readonly string[] SupportedMediaTypes =
+        { "image/png", "image/jpeg", "image/gif", "image/webp" };
+
+    public static bool IsSupported(string mediaType) =>
+        Array.IndexOf(SupportedMediaTypes, mediaType) >= 0;
+
+    /// <summary>Conventional file extension for <see cref="MediaType"/>.</summary>
+    public string Extension => MediaType switch
+    {
+        "image/png" => ".png",
+        "image/jpeg" => ".jpg",
+        "image/gif" => ".gif",
+        "image/webp" => ".webp",
+        _ => ".bin",
+    };
+
+    /// <summary>Data URI for rendering the image in the chat WebView.</summary>
+    public string ToDataUri() => $"data:{MediaType};base64,{Convert.ToBase64String(Data)}";
+}

--- a/src/VsAgentic.Services/Abstractions/IChatService.cs
+++ b/src/VsAgentic.Services/Abstractions/IChatService.cs
@@ -2,7 +2,16 @@ namespace VsAgentic.Services.Abstractions;
 
 public interface IChatService
 {
-    IAsyncEnumerable<string> SendMessageAsync(string userMessage, CancellationToken cancellationToken = default);
+    /// <param name="images">
+    /// Images to send alongside the text. They travel inline as base64 blocks,
+    /// so nothing is written to the project. Null or empty sends text only,
+    /// which keeps the wire format identical to what it was before images
+    /// existed.
+    /// </param>
+    IAsyncEnumerable<string> SendMessageAsync(
+        string userMessage,
+        IReadOnlyList<ChatImageAttachment>? images = null,
+        CancellationToken cancellationToken = default);
     Task<string> GenerateTitleAsync(string userMessage, CancellationToken cancellationToken = default);
     void ClearHistory();
 

--- a/src/VsAgentic.Services/Abstractions/ISessionStore.cs
+++ b/src/VsAgentic.Services/Abstractions/ISessionStore.cs
@@ -22,6 +22,18 @@ public interface ISessionStore
     Task AppendMessageAsync(string folderPath, int sessionId, PersistedMessage message);
 
     // AI conversation history
+    /// <summary>
+    /// Writes an image into the session's <c>images</c> folder and returns the
+    /// generated file name, which the caller stores on the message.
+    /// </summary>
+    Task<string> SaveImageAsync(string folderPath, int sessionId, ChatImageAttachment image);
+
+    /// <summary>
+    /// Loads a previously stored image. Returns null when the file is missing,
+    /// so a deleted or half-copied session still opens.
+    /// </summary>
+    Task<ChatImageAttachment?> GetImageAsync(string folderPath, int sessionId, string fileName);
+
     Task<string?> GetConversationHistoryAsync(string folderPath, int sessionId);
     Task SaveConversationHistoryAsync(string folderPath, int sessionId, string historyJson);
 }

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
@@ -71,6 +71,7 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
 
     public async IAsyncEnumerable<string> SendMessageAsync(
         string userMessage,
+        IReadOnlyList<ChatImageAttachment>? images = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Lazy start: bring the long-running process up if it's not running.
@@ -96,7 +97,9 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         // Send the user message line.
         try
         {
-            var line = StreamJsonProtocol.BuildUserTextMessage(userMessage);
+            var line = images is { Count: > 0 }
+                ? StreamJsonProtocol.BuildUserMessageWithImages(userMessage, images)
+                : StreamJsonProtocol.BuildUserTextMessage(userMessage);
             await _host.WriteLineAsync(line, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/src/VsAgentic.Services/ClaudeCli/StreamJsonProtocol.cs
+++ b/src/VsAgentic.Services/ClaudeCli/StreamJsonProtocol.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using VsAgentic.Services.Abstractions;
 
 namespace VsAgentic.Services.ClaudeCli;
 
@@ -30,6 +31,52 @@ internal static class StreamJsonProtocol
             {
                 role = "user",
                 content = text
+            }
+        };
+        return JsonSerializer.Serialize(msg, SerializerOptions);
+    }
+
+    /// <summary>
+    /// Build the JSON line for a user message carrying one or more images.
+    /// The CLI accepts base64 image blocks inline, so the bytes go straight into
+    /// the conversation without being written to the project first.
+    ///
+    /// Images come before the text: the API reads a prompt that refers to
+    /// "this screenshot" more reliably when the image is already in context.
+    /// </summary>
+    public static string BuildUserMessageWithImages(
+        string text,
+        IReadOnlyList<ChatImageAttachment> images)
+    {
+        var content = new List<object>(images.Count + 1);
+
+        foreach (var image in images)
+        {
+            content.Add(new
+            {
+                type = "image",
+                source = new
+                {
+                    type = "base64",
+                    media_type = image.MediaType,
+                    data = Convert.ToBase64String(image.Data)
+                }
+            });
+        }
+
+        // An empty text block is rejected, so only add one when there is text.
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            content.Add(new { type = "text", text });
+        }
+
+        var msg = new
+        {
+            type = "user",
+            message = new
+            {
+                role = "user",
+                content = content.ToArray()
             }
         };
         return JsonSerializer.Serialize(msg, SerializerOptions);

--- a/src/VsAgentic.Services/Models/PersistedMessage.cs
+++ b/src/VsAgentic.Services/Models/PersistedMessage.cs
@@ -11,5 +11,13 @@ public class PersistedMessage
     public string? BodyMode { get; set; }
     public string? ExpanderTitle { get; set; }
     public string StatusText { get; set; } = "Success";
+
+    /// <summary>
+    /// Names of image files stored in the session's <c>images</c> folder. Only
+    /// the names are kept here so <c>messages.json</c> stays small — the bytes
+    /// would otherwise add megabytes per screenshot.
+    /// </summary>
+    public List<string>? ImageFileNames { get; set; }
+
     public DateTime CreatedUtc { get; set; }
 }

--- a/src/VsAgentic.Services/Services/JsonSessionStore.cs
+++ b/src/VsAgentic.Services/Services/JsonSessionStore.cs
@@ -228,6 +228,65 @@ public class JsonSessionStore : ISessionStore
 
     // --- AI Conversation History ---
 
+    public async Task<string> SaveImageAsync(string folderPath, int sessionId, ChatImageAttachment image)
+    {
+        var imagesDir = Path.Combine(GetSessionDir(folderPath, sessionId), "images");
+        Directory.CreateDirectory(imagesDir);
+
+        var fileName = $"{Guid.NewGuid():N}{image.Extension}";
+        using (var stream = new FileStream(
+                   Path.Combine(imagesDir, fileName),
+                   FileMode.CreateNew, FileAccess.Write, FileShare.None,
+                   bufferSize: 64 * 1024, useAsync: true))
+        {
+            await stream.WriteAsync(image.Data, 0, image.Data.Length);
+        }
+
+        image.FileName = fileName;
+        return fileName;
+    }
+
+    public async Task<ChatImageAttachment?> GetImageAsync(string folderPath, int sessionId, string fileName)
+    {
+        // Guard against a crafted or corrupted messages.json walking out of the
+        // session folder.
+        if (fileName.IndexOfAny(new[] { '/', '\\', ':' }) >= 0 || fileName.Contains(".."))
+            return null;
+
+        var path = Path.Combine(GetSessionDir(folderPath, sessionId), "images", fileName);
+        if (!File.Exists(path))
+            return null;
+
+        byte[] data;
+        using (var stream = new FileStream(
+                   path, FileMode.Open, FileAccess.Read, FileShare.Read,
+                   bufferSize: 64 * 1024, useAsync: true))
+        {
+            data = new byte[stream.Length];
+            var read = 0;
+            while (read < data.Length)
+            {
+                var chunk = await stream.ReadAsync(data, read, data.Length - read);
+                if (chunk == 0) break;
+                read += chunk;
+            }
+        }
+
+        return new ChatImageAttachment(data, MediaTypeFromExtension(Path.GetExtension(fileName)))
+        {
+            FileName = fileName
+        };
+    }
+
+    private static string MediaTypeFromExtension(string extension) => extension.ToLowerInvariant() switch
+    {
+        ".png" => "image/png",
+        ".jpg" or ".jpeg" => "image/jpeg",
+        ".gif" => "image/gif",
+        ".webp" => "image/webp",
+        _ => "application/octet-stream",
+    };
+
     public async Task<string?> GetConversationHistoryAsync(string folderPath, int sessionId)
     {
         var historyPath = Path.Combine(GetSessionDir(folderPath, sessionId), "history.json");

--- a/src/VsAgentic.UI/Assets/chat-template.html
+++ b/src/VsAgentic.UI/Assets/chat-template.html
@@ -129,6 +129,26 @@ html, body {
     border-radius: 4px;
     padding: 8px;
 }
+/* Attached images: thumbnails by default, click to see the whole thing. */
+.msg-images {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 4px 0 8px 0;
+}
+.msg-image {
+    max-height: 120px;
+    max-width: 100%;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: zoom-in;
+    display: block;
+}
+.msg-image.expanded {
+    max-height: none;
+    cursor: zoom-out;
+}
+
 .msg-user .msg-label {
     font-weight: 600;
     font-size: 11px;
@@ -471,11 +491,28 @@ function addMessage(id, type, dataJson) {
         var label = document.createElement('div');
         label.className = 'msg-label';
         label.textContent = 'You';
+        div.appendChild(label);
+
+        if (data.Images && data.Images.length) {
+            var strip = document.createElement('div');
+            strip.className = 'msg-images';
+            for (var ii = 0; ii < data.Images.length; ii++) {
+                var thumb = document.createElement('img');
+                // Data URI built on the host side; never user-authored markup.
+                thumb.src = data.Images[ii];
+                thumb.className = 'msg-image';
+                thumb.addEventListener('click', function() {
+                    this.classList.toggle('expanded');
+                });
+                strip.appendChild(thumb);
+            }
+            div.appendChild(strip);
+        }
+
         var content = document.createElement('div');
         content.className = 'md-content msg-content';
         content.innerHTML = renderUserMd(data.Content || '');
         linkifyFilePaths(content);
-        div.appendChild(label);
         div.appendChild(content);
     }
     else if (type === 'Assistant') {

--- a/src/VsAgentic.UI/Assets/chat-template.html
+++ b/src/VsAgentic.UI/Assets/chat-template.html
@@ -621,6 +621,12 @@ function addMessage(id, type, dataJson) {
                 thumb.addEventListener('click', function() {
                     this.classList.toggle('expanded');
                 });
+                // A thumbnail has no height until it decodes, so the scroll
+                // that follows the prompt runs against a container that is
+                // still too short. Land on the bottom again once it does.
+                thumb.addEventListener('load', function() {
+                    if (!_userScrolledUp) scrollToBottom();
+                });
                 strip.appendChild(thumb);
             }
             div.appendChild(strip);

--- a/src/VsAgentic.UI/Controls/AttachmentPreviewConverter.cs
+++ b/src/VsAgentic.UI/Controls/AttachmentPreviewConverter.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using System.IO;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+using VsAgentic.Services.Abstractions;
+
+namespace VsAgentic.UI.Controls;
+
+/// <summary>
+/// Renders a pending <see cref="ChatImageAttachment"/> as a thumbnail. The bytes
+/// are already in memory, so the preview is decoded from them rather than from
+/// any file on disk.
+/// </summary>
+public sealed class AttachmentPreviewConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not ChatImageAttachment attachment) return null;
+
+        try
+        {
+            var image = new BitmapImage();
+            image.BeginInit();
+            image.CacheOption = BitmapCacheOption.OnLoad;
+            // Decoding at thumbnail height keeps a wall of screenshots from
+            // holding full-size bitmaps in memory.
+            image.DecodePixelHeight = 56;
+            image.StreamSource = new MemoryStream(attachment.Data);
+            image.EndInit();
+            image.Freeze();
+            return image;
+        }
+        catch
+        {
+            // A preview that cannot be decoded is not worth failing the paste
+            // over — the attachment itself still goes out fine.
+            return null;
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/VsAgentic.UI/Controls/ChatWebView.xaml.cs
+++ b/src/VsAgentic.UI/Controls/ChatWebView.xaml.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Windows;
@@ -45,6 +47,7 @@ public partial class ChatWebView : UserControl
                 "VsAgentic", "WebView2");
             var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
             await WebView.EnsureCoreWebView2Async(env);
+            MapImageHost();
             WebView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
             WebView.CoreWebView2.Settings.AreDevToolsEnabled = false;
             WebView.CoreWebView2.Settings.IsStatusBarEnabled = false;
@@ -59,6 +62,116 @@ public partial class ChatWebView : UserControl
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"ChatWebView init failed: {ex.Message}");
+        }
+    }
+
+    // Images are served to the WebView over a virtual host instead of being
+    // inlined as data URIs. A single screenshot runs to a megabyte or more, and
+    // ExecuteScriptAsync takes the whole script as one string — pushing that
+    // much base64 through it kills the WebView2 browser process outright, which
+    // blanks the pane with no exception on our side.
+    private const string ImageHost = "vsagentic-images";
+    private string? _imageFolder;
+
+    private void MapImageHost()
+    {
+        try
+        {
+            // Scoped to the process and cleared on start: this is a render cache,
+            // not storage. The session folder keeps the copies that matter.
+            _imageFolder = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "VsAgentic", "WebView2Images", $"p{Process.GetCurrentProcess().Id}");
+
+            if (Directory.Exists(_imageFolder))
+                Directory.Delete(_imageFolder, recursive: true);
+            Directory.CreateDirectory(_imageFolder);
+
+            // DenyCors, not Deny: the page comes from NavigateToString, so its
+            // origin is not the virtual host and every <img> pointing at it is a
+            // cross-origin request. Deny blocks those outright and the thumbnail
+            // renders as a broken image. DenyCors lets subresources load while
+            // still refusing fetch/XHR against the folder.
+            WebView.CoreWebView2.SetVirtualHostNameToFolderMapping(
+                ImageHost, _imageFolder, CoreWebView2HostResourceAccessKind.DenyCors);
+        }
+        catch (Exception ex)
+        {
+            _imageFolder = null;
+            System.Diagnostics.Debug.WriteLine($"ChatWebView image host mapping failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Writes any data-URI images in the message to the mapped folder and
+    /// rewrites them to short virtual-host URLs, so the script that carries the
+    /// message stays small. Messages without images are returned unchanged.
+    /// </summary>
+    private ChatMessageData MaterializeImages(ChatMessageData data)
+    {
+        if (data.Images is not { Count: > 0 } || _imageFolder is null) return data;
+
+        var urls = new List<string>(data.Images.Count);
+        foreach (var image in data.Images)
+        {
+            urls.Add(WriteImage(image) ?? image);
+        }
+
+        return new ChatMessageData
+        {
+            Id = data.Id,
+            Type = data.Type,
+            Content = data.Content,
+            ToolName = data.ToolName,
+            Title = data.Title,
+            Status = data.Status,
+            ExpanderTitle = data.ExpanderTitle,
+            BodyMode = data.BodyMode,
+            Body = data.Body,
+            IsStreaming = data.IsStreaming,
+            Images = urls
+        };
+    }
+
+    private string? WriteImage(string dataUri)
+    {
+        try
+        {
+            // data:<media type>;base64,<payload>
+            var comma = dataUri.IndexOf(',');
+            if (!dataUri.StartsWith("data:", StringComparison.Ordinal) || comma < 0)
+                return null;
+
+            var mediaType = dataUri.Substring(5, dataUri.IndexOf(';') - 5);
+            var bytes = Convert.FromBase64String(dataUri.Substring(comma + 1));
+
+            var extension = mediaType switch
+            {
+                "image/png" => ".png",
+                "image/jpeg" => ".jpg",
+                "image/gif" => ".gif",
+                "image/webp" => ".webp",
+                _ => ".bin",
+            };
+
+            // Content-addressed, so the same image reused across messages is
+            // written once.
+            string name;
+            using (var sha = System.Security.Cryptography.SHA256.Create())
+            {
+                name = BitConverter.ToString(sha.ComputeHash(bytes), 0, 8).Replace("-", "") + extension;
+            }
+
+            var path = Path.Combine(_imageFolder!, name);
+            if (!File.Exists(path))
+                File.WriteAllBytes(path, bytes);
+
+            return $"https://{ImageHost}/{name}";
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"ChatWebView image write failed: {ex.Message}");
+            return null;
         }
     }
 
@@ -121,7 +234,7 @@ public partial class ChatWebView : UserControl
 
     public Task AddMessageAsync(string id, ChatItemType type, ChatMessageData data)
     {
-        var dataJson = JsonSerializer.Serialize(data);
+        var dataJson = JsonSerializer.Serialize(MaterializeImages(data));
         return ExecuteOrQueueAsync(
             $"addMessage({JsonSerializer.Serialize(id)}, {JsonSerializer.Serialize(type.ToString())}, {dataJson})");
     }
@@ -157,7 +270,7 @@ public partial class ChatWebView : UserControl
 
     public Task LoadMessagesAsync(IEnumerable<ChatMessageData> messages)
     {
-        var json = JsonSerializer.Serialize(messages);
+        var json = JsonSerializer.Serialize(messages.Select(MaterializeImages));
         return ExecuteOrQueueAsync($"loadMessages({json})");
     }
 

--- a/src/VsAgentic.UI/Controls/ClipboardImage.cs
+++ b/src/VsAgentic.UI/Controls/ClipboardImage.cs
@@ -1,0 +1,97 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using VsAgentic.Services.Abstractions;
+
+namespace VsAgentic.UI.Controls;
+
+/// <summary>
+/// Turns whatever the clipboard is holding into an attachment the CLI accepts.
+/// </summary>
+public static class ClipboardImage
+{
+    /// <summary>
+    /// Anthropic resizes anything larger than this before the model sees it, and
+    /// bills for the full upload either way, so shrink first. Screenshots from a
+    /// 4K monitor are several megabytes; base64 adds another third on top.
+    /// </summary>
+    private const int MaxEdge = 1568;
+
+    /// <summary>
+    /// Reads an image from the clipboard, or returns null when there is none.
+    /// Handles both a bitmap (a screenshot, or a copy out of an image editor)
+    /// and a copied image file.
+    /// </summary>
+    public static ChatImageAttachment? TryRead()
+    {
+        try
+        {
+            if (Clipboard.ContainsFileDropList())
+            {
+                foreach (var path in Clipboard.GetFileDropList())
+                {
+                    var attachment = TryReadFile(path);
+                    if (attachment is not null) return attachment;
+                }
+            }
+
+            if (Clipboard.ContainsImage())
+            {
+                var source = Clipboard.GetImage();
+                if (source is not null)
+                    return FromBitmapSource(source);
+            }
+        }
+        catch
+        {
+            // The clipboard is shared with every other process on the machine and
+            // can fail for reasons that have nothing to do with us. Pasting
+            // nothing is the right answer.
+        }
+
+        return null;
+    }
+
+    private static ChatImageAttachment? TryReadFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path)) return null;
+
+        var mediaType = Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".webp" => "image/webp",
+            _ => null,
+        };
+        if (mediaType is null) return null;
+
+        // Re-encode through the decoder so oversized files get shrunk too. GIF is
+        // passed through untouched: decoding keeps only the first frame, which
+        // would silently drop the animation.
+        if (mediaType == "image/gif")
+            return new ChatImageAttachment(File.ReadAllBytes(path!), mediaType);
+
+        var decoded = new BitmapImage();
+        decoded.BeginInit();
+        decoded.CacheOption = BitmapCacheOption.OnLoad;
+        decoded.UriSource = new Uri(path!);
+        decoded.EndInit();
+        return FromBitmapSource(decoded);
+    }
+
+    private static ChatImageAttachment FromBitmapSource(BitmapSource source)
+    {
+        var scale = Math.Min(1.0, (double)MaxEdge / Math.Max(source.PixelWidth, source.PixelHeight));
+        BitmapSource final = scale < 1.0
+            ? new TransformedBitmap(source, new System.Windows.Media.ScaleTransform(scale, scale))
+            : source;
+
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(final));
+
+        using var stream = new MemoryStream();
+        encoder.Save(stream);
+        return new ChatImageAttachment(stream.ToArray(), "image/png");
+    }
+}

--- a/src/VsAgentic.UI/ViewModels/ChatMessageData.cs
+++ b/src/VsAgentic.UI/ViewModels/ChatMessageData.cs
@@ -18,4 +18,10 @@ public class ChatMessageData
     public string BodyMode { get; init; } = "Markdown";
     public string? Body { get; init; }
     public bool IsStreaming { get; init; }
+
+    /// <summary>
+    /// Data URIs for images attached to a user message, rendered inside the
+    /// prompt block. Null when the message has none.
+    /// </summary>
+    public List<string>? Images { get; init; }
 }

--- a/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
@@ -311,6 +311,20 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
                     Status = ParseEnum<OutputItemStatus>(msg.StatusText),
                     IsStreaming = false
                 });
+                List<string>? imageDataUris = null;
+                if (msg.ImageFileNames is { Count: > 0 })
+                {
+                    imageDataUris = new List<string>(msg.ImageFileNames.Count);
+                    foreach (var fileName in msg.ImageFileNames)
+                    {
+                        // A missing file just means one thumbnail short; the rest
+                        // of the conversation still restores.
+                        var stored = await store.GetImageAsync(folder, sessionId.Value, fileName);
+                        if (stored is not null)
+                            imageDataUris.Add(stored.ToDataUri());
+                    }
+                }
+
                 restoreData.Add(new ChatMessageData
                 {
                     Id = $"restore-{msgIndex++}",
@@ -322,7 +336,8 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
                     BodyMode = msg.BodyMode ?? "Markdown",
                     ExpanderTitle = msg.ExpanderTitle ?? "",
                     Status = msg.StatusText,
-                    IsStreaming = false
+                    IsStreaming = false,
+                    Images = imageDataUris is { Count: > 0 } ? imageDataUris : null
                 });
             }
             if (restoreData.Count > 0)
@@ -340,13 +355,48 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
         }
     }
 
-    private bool CanSend() => !IsBusy && !string.IsNullOrWhiteSpace(InputText);
+    // An image on its own is a perfectly good prompt — "what is wrong here?" is
+    // often implicit — so text is only required when nothing is attached.
+    private bool CanSend() =>
+        !IsBusy && (!string.IsNullOrWhiteSpace(InputText) || PendingImages.Count > 0);
+
+    /// <summary>
+    /// Images pasted into the input box, waiting to go out with the next message.
+    /// </summary>
+    public ObservableCollection<ChatImageAttachment> PendingImages { get; } = new();
+
+    /// <summary>
+    /// Attaches an image to the next message. Called by the host when the user
+    /// pastes one into the input box.
+    /// </summary>
+    public void AttachImage(ChatImageAttachment image)
+    {
+        PendingImages.Add(image);
+        SendCommand.NotifyCanExecuteChanged();
+    }
+
+    public void RemovePendingImage(ChatImageAttachment image)
+    {
+        PendingImages.Remove(image);
+        SendCommand.NotifyCanExecuteChanged();
+    }
 
     [RelayCommand(CanExecute = nameof(CanSend))]
     private async Task SendAsync()
     {
         var message = InputText.Trim();
         InputText = "";
+
+        var sentImages = PendingImages.Count > 0
+            ? PendingImages.ToList()
+            : null;
+        PendingImages.Clear();
+        SendCommand.NotifyCanExecuteChanged();
+
+        // Written next to the session so reopening it shows the images again.
+        var storedImageNames = sentImages is null
+            ? null
+            : await PersistImagesAsync(sentImages);
 
         var userMsgId = $"user-{++_userMsgCounter}";
         Items.Add(new ChatItemViewModel
@@ -360,7 +410,8 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             Id = userMsgId,
             Type = "User",
             Content = message,
-            Title = "You"
+            Title = "You",
+            Images = sentImages?.Select(i => i.ToDataUri()).ToList()
         });
         RequestScroll();
 
@@ -369,6 +420,7 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             ItemType = ChatItemType.User.ToString(),
             Content = message,
             Title = "You",
+            ImageFileNames = storedImageNames,
             CreatedUtc = DateTime.UtcNow
         });
 
@@ -416,7 +468,7 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
         var token = _sendCts.Token;
         try
         {
-            await foreach (var _ in _chatService.SendMessageAsync(message, token))
+            await foreach (var _ in _chatService.SendMessageAsync(message, sentImages, token))
             {
                 // Output is handled by listener callbacks
             }
@@ -616,6 +668,37 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
     }
 
     // --- Persistence helpers (fire-and-forget) ---
+
+    /// <summary>
+    /// Writes attachments into the session folder before the message that
+    /// references them is appended, so a reopened session never points at files
+    /// that are not there yet. Awaited rather than fire-and-forget for that
+    /// reason. Returns null when persistence is off or every write failed.
+    /// </summary>
+    private async Task<List<string>?> PersistImagesAsync(IReadOnlyList<ChatImageAttachment> images)
+    {
+        var store = ActiveStore;
+        var folder = ActiveFolder;
+        var sessionId = ActiveSessionId;
+        if (store is null || folder is null || !sessionId.HasValue) return null;
+
+        var names = new List<string>(images.Count);
+        foreach (var image in images)
+        {
+            try
+            {
+                names.Add(await store.SaveImageAsync(folder, sessionId.Value, image));
+            }
+            catch (Exception ex)
+            {
+                // The message still goes out with the image inline; only the
+                // stored copy is lost, so this must not abort the send.
+                _logger.LogWarning(ex, "[VM] Could not store attached image");
+            }
+        }
+
+        return names.Count > 0 ? names : null;
+    }
 
     private void PersistMessageFireAndForget(PersistedMessage message)
     {

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
@@ -10,6 +10,7 @@
 
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <controls:AttachmentPreviewConverter x:Key="AttachmentPreviewConverter"/>
 
         <!-- Banner DataTemplates: ContentControl below picks the right view by VM type. -->
         <DataTemplate DataType="{x:Type bvm:PermissionBannerViewModel}">
@@ -141,12 +142,58 @@
                         SnapsToDevicePixels="True">
                     <Grid>
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
+                        <!-- Pasted images waiting to go out with the next message -->
+                        <ItemsControl Grid.Row="0"
+                                      ItemsSource="{Binding PendingImages}"
+                                      Margin="8,6,8,0">
+                            <ItemsControl.Style>
+                                <Style TargetType="ItemsControl">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding PendingImages.Count}" Value="0">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ItemsControl.Style>
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Margin="0,0,6,6"
+                                            BorderThickness="1"
+                                            CornerRadius="3"
+                                            BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}">
+                                        <Grid>
+                                            <Image Source="{Binding Converter={StaticResource AttachmentPreviewConverter}}"
+                                                   Height="56"
+                                                   Stretch="Uniform"
+                                                   Margin="2"/>
+                                            <Button Content="&#xE10A;"
+                                                    FontFamily="Segoe MDL2 Assets"
+                                                    FontSize="9"
+                                                    Width="16" Height="16"
+                                                    Padding="0"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Top"
+                                                    ToolTip="Remove image"
+                                                    Click="RemoveAttachment_Click"/>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
                         <!-- Text input + placeholder overlay -->
-                        <Grid Grid.Row="0">
+                        <Grid Grid.Row="1">
                             <TextBox x:Name="InputTextBox"
                                      Text="{Binding InputText, UpdateSourceTrigger=PropertyChanged}"
                                      Background="Transparent"
@@ -233,7 +280,7 @@
                         </Grid>
 
                         <!-- Status bar (separated from textbox by a top line) -->
-                        <Border Grid.Row="1"
+                        <Border Grid.Row="2"
                                 BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
                                 BorderThickness="0,1,0,0">
                             <Grid>

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
+using VsAgentic.Services.Abstractions;
 using VsAgentic.UI.Controls;
 using VsAgentic.UI.ViewModels;
 
@@ -102,6 +103,15 @@ public partial class ChatSessionControl : UserControl
         colors["--scrollbar-thumb-hover"] = $"rgba({grayHover.R}, {grayHover.G}, {grayHover.B}, 0.8)";
 
         _ = ChatWebView.SetThemeColorsAsync(colors);
+    }
+
+    private void RemoveAttachment_Click(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is ChatSessionViewModel vm &&
+            sender is FrameworkElement { DataContext: ChatImageAttachment image })
+        {
+            vm.RemovePendingImage(image);
+        }
     }
 
     private void InputTextBox_KeyDown(object sender, KeyEventArgs e)
@@ -263,6 +273,25 @@ public partial class ChatSessionControl : UserControl
 
     private void InputTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
     {
+        // Ctrl+V is caught here rather than through DataObject.Pasting. A
+        // screenshot sits on the clipboard as a bitmap with no text format, so
+        // TextBoxBase.CanPaste is false, the paste command never runs, and the
+        // Pasting event never fires — the keystroke would be swallowed silently.
+        if (e.Key == Key.V && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+        {
+            if (DataContext is ChatSessionViewModel vm)
+            {
+                var image = ClipboardImage.TryRead();
+                if (image is not null)
+                {
+                    vm.AttachImage(image);
+                    // Otherwise a copied image file would also paste its path.
+                    e.Handled = true;
+                    return;
+                }
+            }
+        }
+
         if (!MentionPopup.IsOpen) return;
 
         switch (e.Key)


### PR DESCRIPTION
Fixes #7

### Why it is straightforward

The CLI already accepts this. An image travels as a base64 content block in the same stream-json line as the text, and `StreamJsonProtocol` was halfway there — `BuildToolResultMessage` already sends `content` as an array. Only a plain user message needed the same shape. I verified the wire format against the real CLI before writing any UI.

### Change

**Protocol.** `BuildUserMessageWithImages` puts the images ahead of the text. With no images the message stays a plain string, so the format is unchanged for every existing send.

**Input.** Ctrl+V attaches whatever image the clipboard holds — a screenshot or a copied image file. The key is caught in `PreviewKeyDown`, not through `DataObject.Pasting`: a screenshot is a bitmap with no text format, so `TextBoxBase.CanPaste` is false, the paste command never runs, and `Pasting` never fires.

Attachments appear as thumbnails above the input with a remove button, and send no longer requires text — an image on its own is a fine prompt.

**Size.** Scaled to 1568px on the long edge. Anthropic resizes anything larger before the model sees it and bills for the full upload either way.

**Persistence.** Copies go to the session's `images` folder, with only file names in `messages.json`. Reopening a session shows the images again without the transcript growing by megabytes per screenshot.

**Rendering.** The WebView gets them over a virtual host mapping rather than as data URIs. `ExecuteScriptAsync` takes the whole script as one string, and a megabyte of base64 through it kills the WebView2 browser process — the chat pane blanks with no exception raised. The mapping uses `DenyCors`, since the page comes from `NavigateToString` and every `<img>` is therefore cross-origin; plain `Deny` blocks them.

PNG, JPEG, GIF and WebP are accepted, several images per message. GIF is passed through without re-encoding, since decoding keeps only the first frame and would silently drop the animation.

### Not included

Clipboard paste is the only way in. Two obvious alternatives are missing:

- dragging an image file onto the input box
- an attach button that opens a file dialog

Both would reuse the same attachment path — `ChatSessionViewModel.AttachImage` takes a `ChatImageAttachment` and does not care where it came from — so each is mostly UI work. I left them out to keep this reviewable, and because #7 asks for pasting specifically. Happy to add either here or in a follow-up, whichever you prefer.

### Verified

Screenshot and copied file, one image and two at once, image with and without text, remove before sending, and reopening a session with images in its history.

### Note on ordering

This touches `chat-template.html`, as does #21. Whichever lands second will need a small rebase — the overlap is the user message block in `addMessage` and its neighbouring CSS.

No version bump included, same as the other PRs.
