### PR TITLE
Add a copy button to every code block in the chat

### DIFF
--- a/src/VsAgentic.UI/Assets/chat-template.html
+++ b/src/VsAgentic.UI/Assets/chat-template.html
@@ -88,6 +88,10 @@ html, body {
 .msg:hover .msg-copy-btn {
     opacity: 1;
 }
+.msg.code-hover .msg-copy-btn {
+    opacity: 0;
+    pointer-events: none;
+}
 .msg-copy-btn:hover {
     color: var(--text-primary);
     background: var(--bg-input);
@@ -312,6 +316,44 @@ html, body {
     font-size: 12px;
     color: var(--text-primary);
 }
+/* Copy button on code blocks. The <pre> is wrapped in .code-block so the
+   button stays pinned when the code scrolls horizontally inside the <pre>. */
+.code-block {
+    position: relative;
+}
+.code-block > pre {
+    /* Room for the button so it never sits on top of the first code line. */
+    padding-right: 36px;
+}
+.code-copy-btn {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 22px;
+    height: 22px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.45;
+    transition: opacity 0.15s;
+    z-index: 5;
+    padding: 0;
+    line-height: 1;
+}
+.code-block:hover .code-copy-btn { opacity: 1; }
+.code-copy-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-input);
+}
+.code-copy-btn.copied {
+    color: var(--success);
+    opacity: 1;
+}
 .md-content blockquote {
     border-left: 3px solid var(--accent);
     margin: 0.5em 0;
@@ -475,6 +517,7 @@ function addMessage(id, type, dataJson) {
         content.className = 'md-content msg-content';
         content.innerHTML = renderUserMd(data.Content || '');
         linkifyFilePaths(content);
+        addCodeCopyButtons(content);
         div.appendChild(label);
         div.appendChild(content);
     }
@@ -490,6 +533,7 @@ function addMessage(id, type, dataJson) {
         if (data.IsStreaming) content.classList.add('streaming-cursor');
         content.innerHTML = renderMd(data.Content || '');
         linkifyFilePaths(content);
+        addCodeCopyButtons(content);
         inner.appendChild(bullet);
         inner.appendChild(content);
         div.appendChild(inner);
@@ -627,6 +671,7 @@ function updateContent(id, contentMarkdown) {
             if (mc) {
                 mc.innerHTML = type === 'User' ? renderUserMd(contentMarkdown) : renderMd(contentMarkdown);
                 linkifyFilePaths(mc);
+                addCodeCopyButtons(mc);
             }
         } else if (type === 'ToolStep' || type === 'Thinking') {
             var sc = el.querySelector('.msg-streaming-content');
@@ -663,6 +708,7 @@ function setBody(id, bodyContent, bodyMode) {
         body.innerHTML = renderMd(bodyContent);
     }
     linkifyFilePaths(body);
+    addCodeCopyButtons(body);
     body.style.display = '';
 
     // Apply cap and show-more link
@@ -789,6 +835,58 @@ function copyToClipboard(text) {
     document.body.removeChild(ta);
 }
 
+function flashCopied(btn) {
+    btn.innerHTML = ICON_CHECK;
+    btn.classList.add('copied');
+    setTimeout(function() {
+        btn.innerHTML = ICON_COPY;
+        btn.classList.remove('copied');
+    }, 1500);
+}
+
+// Give every fenced code block its own copy button, so a prompt or snippet
+// can be taken without selecting it by hand.
+function addCodeCopyButtons(container) {
+    var pres = container.querySelectorAll('pre');
+    for (var i = 0; i < pres.length; i++) {
+        var pre = pres[i];
+        if (pre.parentNode && pre.parentNode.classList.contains('code-block')) continue;
+
+        var wrap = document.createElement('div');
+        wrap.className = 'code-block';
+        pre.parentNode.insertBefore(wrap, pre);
+        wrap.appendChild(pre);
+
+        var btn = document.createElement('button');
+        btn.className = 'code-copy-btn';
+        btn.title = 'Copy code to clipboard';
+        btn.innerHTML = ICON_COPY;
+        // Bind per-iteration so the handler copies its own block.
+        btn.addEventListener('click', (function(target, button) {
+            return function(e) {
+                e.stopPropagation();
+                var code = target.querySelector('code');
+                var text = (code || target).innerText;
+                if (!text) return;
+                copyToClipboard(text.replace(/\n$/, ''));
+                flashCopied(button);
+            };
+        })(pre, btn));
+        wrap.appendChild(btn);
+
+        // A code block at the very top of a message would sit under the
+        // message-level copy button; yield to the code button while hovering.
+        wrap.addEventListener('mouseenter', function() {
+            var msg = this.closest('.msg');
+            if (msg) msg.classList.add('code-hover');
+        });
+        wrap.addEventListener('mouseleave', function() {
+            var msg = this.closest('.msg');
+            if (msg) msg.classList.remove('code-hover');
+        });
+    }
+}
+
 function addCopyButton(msgDiv) {
     var btn = document.createElement('button');
     btn.className = 'msg-copy-btn';
@@ -799,12 +897,7 @@ function addCopyButton(msgDiv) {
         var text = getMessageText(msgDiv);
         if (!text) return;
         copyToClipboard(text);
-        btn.innerHTML = ICON_CHECK;
-        btn.classList.add('copied');
-        setTimeout(function() {
-            btn.innerHTML = ICON_COPY;
-            btn.classList.remove('copied');
-        }, 1500);
+        flashCopied(btn);
     });
     msgDiv.appendChild(btn);
 }


### PR DESCRIPTION
Fixes #23

### Change

All of it is in `chat-template.html`.

**Rendering.** `addCodeCopyButtons(container)` walks the `<pre>` elements of a
freshly rendered container, wraps each one in a `div.code-block` and appends a
button to the wrapper:

```css
.code-block { position: relative; }
.code-block > pre { padding-right: 36px; }
.code-copy-btn { position: absolute; top: 6px; right: 6px; opacity: 0.45; }
.code-block:hover .code-copy-btn { opacity: 1; }
```

The wrapper is the point of the exercise. `.md-content pre` is
`overflow-x: auto`, so a button placed inside the `<pre>` would scroll away with
the code — which is exactly the case the button is meant to help with. The
wrapper does not scroll, so the button stays in the corner. The right padding on
the `<pre>` keeps the first line of code from running underneath it.

It is called next to each existing `linkifyFilePaths` call — user message,
assistant message, `updateContent`, and `setBody` — so it covers every path that
turns markdown into DOM. The function skips a `<pre>` that is already wrapped,
which makes it safe to call repeatedly while a message streams and its content
is re-rendered on every frame.

**Copying.** Copy takes `innerText` of the inner `<code>` with the trailing
newline trimmed, so the clipboard holds the snippet and nothing else. It reuses
the existing `copyToClipboard`; the check mark feedback that the message-level
button already had is now a shared `flashCopied(btn)` helper, so both buttons
behave identically.

**Overlap with the message button.** A code block at the top of a message would
sit under `.msg-copy-btn`, which is anchored at `top: 4px; right: 4px`. Hovering
a code block adds `code-hover` to the enclosing `.msg`, which hides the
message-level button for as long as the pointer is there, so only one button is
ever visible in that corner.

`getMessageText` is unaffected: the new button holds an SVG only, so it
contributes nothing to the `innerText` that the message-level copy reads.

### Verified

Built and deployed into the experimental instance, then used in a live session:
single and multiple blocks per message, a block wide enough to scroll sideways,
a block as the first element of a message (the overlap case), blocks arriving
during streaming, and blocks inside a tool step body. Copying a whole message
still works as before.

### Note on ordering

This touches `chat-template.html`, as do #21 and #22. It is branched from `main`,
so whichever of the three lands first, this one needs a small rebase — the
overlap is one line in the user message branch of `addMessage`, next to the
`linkifyFilePaths` call.

No version bump included, same as the other PRs.
