### PR TITLE
Show token usage, model and effort in the status bar of every chat window

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Settings are available in the Visual Studio **Tools → Options → VsAgentic** 
 
 - **Claude CLI Path** — path to the `claude` executable (defaults to `claude` on PATH)
 - **CLI Permission Mode** — controls how the CLI handles tool permissions
+- **Model** / **Reasoning effort** — remembered from the dropdowns in the chat header
+- **Plan** — which subscription the usage meters are sized against (`Unlimited` hides them)
+- **5-hour / weekly token budget** — override the estimated limits behind those meters
 
 ### 🧰 Built-in Agentic Tools
 Claude Code comes with a full suite of agentic tools — file search, code search, file reading/editing, bash commands, web fetching, and sub-agent delegation. The CLI manages all tools natively; VsAgentic displays tool steps inline so you can follow every action.
@@ -32,6 +35,16 @@ Claude Code comes with a full suite of agentic tools — file search, code searc
 - Conversation history is fully restored when you reopen VS
 - Auto-generated session titles based on your first message
 - Manage sessions from the **VsAgentic Sessions** panel (open, rename, delete)
+
+### 📊 Usage Header
+Every chat window carries a header showing where your tokens are going:
+
+- **Context** — how full the model's context window is, so a compaction is never a surprise
+- **5h / 7d** — tokens spent in the trailing rate-limit windows, counted across every session on the machine and kept between restarts
+- **Session** — what this conversation has cost so far, broken down by input, output and cache in the tooltip
+- **Model / effort** dropdowns — switch either without leaving the chat; the conversation is resumed, not lost
+
+The rate-limit budgets are estimates — Anthropic does not publish the real limits — so the meters are a gauge, not an authority. Adjust them under **Tools → Options → VsAgentic** if you have measured your own.
 
 ### 🖼️ Rich Markdown Rendering
 Responses are rendered with full Markdown support — syntax-highlighted code blocks, tables, lists, and inline formatting — via an embedded WebView2 control.

--- a/src/VsAgentic.Services/Abstractions/IChatService.cs
+++ b/src/VsAgentic.Services/Abstractions/IChatService.cs
@@ -1,3 +1,5 @@
+using VsAgentic.Services.Configuration;
+
 namespace VsAgentic.Services.Abstractions;
 
 public interface IChatService
@@ -21,6 +23,29 @@ public interface IChatService
     /// Returns null when no messages have been sent yet.
     /// </summary>
     decimal? GetSessionCost();
+
+    /// <summary>
+    /// Token usage for this session, plus the rolling machine-wide windows, as
+    /// of now. Never null — a session that has sent nothing reports zeroes.
+    /// </summary>
+    SessionUsage GetUsage();
+
+    /// <summary>
+    /// Raised after each API call the CLI reports usage for, carrying the same
+    /// snapshot <see cref="GetUsage"/> would return. Fires on a background
+    /// thread; hosts must marshal to their UI thread.
+    /// </summary>
+    event Action<SessionUsage>? UsageChanged;
+
+    /// <summary>
+    /// Switches the model and/or reasoning effort for this session.
+    ///
+    /// Both are start-up flags on the CLI, so the running process is torn down
+    /// here and the next <see cref="SendMessageAsync"/> starts a fresh one that
+    /// resumes the same conversation. Nothing is lost, but the next message
+    /// pays the process-start cost. A no-op when neither value changed.
+    /// </summary>
+    void ApplyModelAndEffort(string modelAlias, ClaudeEffort effort);
 
     /// <summary>
     /// Raised when the underlying CLI returned an authentication / login-required

--- a/src/VsAgentic.Services/Abstractions/SessionUsage.cs
+++ b/src/VsAgentic.Services/Abstractions/SessionUsage.cs
@@ -1,0 +1,118 @@
+using System;
+using VsAgentic.Services.Configuration;
+
+namespace VsAgentic.Services.Abstractions;
+
+/// <summary>
+/// How alarming a meter reading is. Kept as a named level rather than a raw
+/// fraction so the thresholds live in one place and the XAML can switch colours
+/// on a trigger instead of arithmetic.
+/// </summary>
+public enum UsageLevel
+{
+    Normal,
+    Warning,
+    Critical,
+}
+
+/// <summary>
+/// What a session has spent, as of one moment. Snapshots are handed to the UI
+/// whole rather than as a set of mutable counters, so the header can never
+/// render a half-updated row (e.g. new totals against a stale context window).
+///
+/// Three different things are counted here and they are not interchangeable:
+///  - <see cref="TotalTokens"/> is everything this session has ever sent or
+///    received. It only grows.
+///  - <see cref="ContextTokens"/> is how full the model's context window was on
+///    the last call. It falls back down after a compaction.
+///  - The rolling windows are machine-wide, span every session and survive a
+///    restart, because that is the scope the rate limit itself applies at.
+/// </summary>
+public record SessionUsage
+{
+    public static readonly SessionUsage Empty = new();
+
+    // ── Session totals ────────────────────────────────────────────────────
+
+    public long InputTokens { get; init; }
+
+    public long OutputTokens { get; init; }
+
+    public long CacheReadTokens { get; init; }
+
+    public long CacheCreationTokens { get; init; }
+
+    public long TotalTokens =>
+        InputTokens + OutputTokens + CacheReadTokens + CacheCreationTokens;
+
+    /// <summary>Cumulative USD, as reported by the CLI. Null until the first result event.</summary>
+    public decimal? CostUsd { get; init; }
+
+    // ── Context window ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Tokens the last API call carried into the model: fresh input, plus both
+    /// halves of the cache, plus what came back out. This is the number that has
+    /// to stay under <see cref="ContextWindowTokens"/>.
+    /// </summary>
+    public long ContextTokens { get; init; }
+
+    public int ContextWindowTokens { get; init; } = ClaudeModelCatalog.StandardContextWindowTokens;
+
+    public double ContextFraction => Fraction(ContextTokens, ContextWindowTokens);
+
+    // ── Rolling rate-limit windows ────────────────────────────────────────
+
+    /// <summary>Tokens spent in the trailing 5 hours, across every session.</summary>
+    public long ShortWindowTokens { get; init; }
+
+    /// <summary>Tokens spent in the trailing 7 days, across every session.</summary>
+    public long LongWindowTokens { get; init; }
+
+    /// <summary>Budget the short window is measured against; 0 means "no cap known", and the meter hides.</summary>
+    public long ShortWindowBudget { get; init; }
+
+    /// <summary>Budget the long window is measured against; 0 means "no cap known", and the meter hides.</summary>
+    public long LongWindowBudget { get; init; }
+
+    public double ShortWindowFraction => Fraction(ShortWindowTokens, ShortWindowBudget);
+
+    public double LongWindowFraction => Fraction(LongWindowTokens, LongWindowBudget);
+
+    public bool HasWindowBudget => ShortWindowBudget > 0 || LongWindowBudget > 0;
+
+    // ── What is actually running ──────────────────────────────────────────
+
+    /// <summary>
+    /// Concrete model id from the CLI's <c>system/init</c> event (e.g.
+    /// <c>claude-opus-5</c>). Null until the first turn — the selected alias
+    /// resolves server-side, so this is the only honest source.
+    /// </summary>
+    public string? ModelId { get; init; }
+
+    public bool HasAny => TotalTokens > 0;
+
+    public UsageLevel ContextLevel => LevelOf(ContextFraction);
+
+    public UsageLevel ShortWindowLevel => LevelOf(ShortWindowFraction);
+
+    public UsageLevel LongWindowLevel => LevelOf(LongWindowFraction);
+
+    /// <summary>
+    /// Warn at three quarters, escalate at nine tenths. The warning band is
+    /// wide on purpose: the point is to be told while there is still room to
+    /// change course, not once the decision has been made for you.
+    /// </summary>
+    private static UsageLevel LevelOf(double fraction) =>
+        fraction >= 0.90 ? UsageLevel.Critical :
+        fraction >= 0.75 ? UsageLevel.Warning :
+        UsageLevel.Normal;
+
+    /// <summary>
+    /// Clamped so a meter can never render past its track. Over-budget is a
+    /// state we expect to see: the budgets are estimates, so going past one
+    /// says the estimate was low, not that usage is impossible.
+    /// </summary>
+    private static double Fraction(long used, long budget) =>
+        budget <= 0 ? 0d : Math.Min(1d, Math.Max(0d, (double)used / budget));
+}

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
@@ -46,6 +46,27 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
     private Task? _dispatcherTask;
     private readonly object _dispatcherLock = new object();
 
+    // ── Token usage ───────────────────────────────────────────────────────
+    // Accumulated from the usage block on each assistant event. The result
+    // event also carries a usage object, but it is a turn-level aggregate, so
+    // reading both would double-count; the per-message blocks are the finer
+    // grained of the two and are what the context meter needs anyway.
+    private readonly object _usageLock = new object();
+    private long _inputTokens;
+    private long _outputTokens;
+    private long _cacheReadTokens;
+    private long _cacheCreationTokens;
+    private long _contextTokens;
+    private string? _modelId;
+
+    // The CLI can emit more than one assistant event carrying the same message
+    // id (the usage block is repeated verbatim on each). Counting per id rather
+    // than per event keeps a single API call from being billed to the meter
+    // several times over.
+    private readonly HashSet<string> _countedMessageIds = new HashSet<string>(StringComparer.Ordinal);
+
+    private readonly UsageLog _usageLog = UsageLog.Shared;
+
     // The dispatcher consumes events from the host and routes them to whichever
     // turn is currently active. We only ever have one active turn at a time —
     // SendMessageAsync calls are serialized by the UI (IsBusy gate) — so a
@@ -224,6 +245,16 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
             _cliSessionId = sid.GetString();
             _logger.LogDebug("[ClaudeCli] Session started: {SessionId}", _cliSessionId);
         }
+
+        // The alias we pass to --model resolves server-side, so this init event
+        // is the only place that names the model actually serving the session —
+        // and with it the context window the meter measures against.
+        if (evt.TryGetProperty("model", out var model) && model.ValueKind == JsonValueKind.String)
+        {
+            lock (_usageLock) { _modelId = model.GetString(); }
+            _logger.LogInformation("[ClaudeCli] Model: {Model}", _modelId);
+            RaiseUsageChanged();
+        }
         // Diagnostic: dump the available tool names so we can verify whether
         // AskUserQuestion is registered in headless mode.
         if (evt.TryGetProperty("tools", out var tools) && tools.ValueKind == JsonValueKind.Array)
@@ -246,6 +277,11 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         if (turn == null) return;
 
         if (!evt.TryGetProperty("message", out var msg)) return;
+
+        // Before the content check: a message can carry usage worth counting
+        // even when its content block is one we do not render.
+        AccountUsage(msg);
+
         if (!msg.TryGetProperty("content", out var contentArr)) return;
         if (contentArr.ValueKind != JsonValueKind.Array) return;
 
@@ -433,7 +469,10 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         else
         {
             if (evt.TryGetProperty("cost_usd", out var cost) && cost.ValueKind == JsonValueKind.Number)
+            {
                 _cumulativeCostUsd += cost.GetDecimal();
+                RaiseUsageChanged();
+            }
         }
 
         // Signal SendMessageAsync to return.
@@ -724,13 +763,175 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
 
     public decimal? GetSessionCost() => _cumulativeCostUsd > 0 ? _cumulativeCostUsd : null;
 
+    // ── Usage accounting ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Folds one assistant message's <c>usage</c> block into the session totals
+    /// and the machine-wide rolling log.
+    /// </summary>
+    private void AccountUsage(JsonElement message)
+    {
+        if (!message.TryGetProperty("usage", out var usage) || usage.ValueKind != JsonValueKind.Object)
+            return;
+
+        var input = ReadTokenCount(usage, "input_tokens");
+        var output = ReadTokenCount(usage, "output_tokens");
+        var cacheRead = ReadTokenCount(usage, "cache_read_input_tokens");
+        var cacheCreate = ReadTokenCount(usage, "cache_creation_input_tokens");
+
+        // Everything the call carried — this is the number that has to fit the
+        // context window, so cache reads count in full here even though they
+        // are discounted for billing.
+        var context = input + output + cacheRead + cacheCreate;
+        if (context <= 0) return;
+
+        var messageId = message.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String
+            ? idProp.GetString()
+            : null;
+
+        lock (_usageLock)
+        {
+            // No id means we cannot tell a repeat from a new call, so we count
+            // it and accept the risk of a small overcount — better than
+            // dropping usage we did incur.
+            if (messageId is not null && !_countedMessageIds.Add(messageId))
+                return;
+
+            // Ids are only ever needed to spot an immediate repeat; a long
+            // session should not accumulate them without bound.
+            if (_countedMessageIds.Count > 4096)
+            {
+                _countedMessageIds.Clear();
+                if (messageId is not null) _countedMessageIds.Add(messageId);
+            }
+
+            _inputTokens += input;
+            _outputTokens += output;
+            _cacheReadTokens += cacheRead;
+            _cacheCreationTokens += cacheCreate;
+
+            // Assigned, not accumulated: this is an occupancy reading, and it
+            // drops back down when the CLI compacts the conversation.
+            _contextTokens = context;
+        }
+
+        // Cache reads are charged at a fraction of a fresh input token, so
+        // counting them in full here would have the rate-limit meter racing
+        // ahead of the real limit on exactly the long sessions where caching
+        // helps most. A tenth is the published ratio.
+        _usageLog.Record(input + output + cacheCreate + cacheRead / 10);
+
+        RaiseUsageChanged();
+    }
+
+    private static long ReadTokenCount(JsonElement usage, string name) =>
+        usage.TryGetProperty(name, out var p)
+        && p.ValueKind == JsonValueKind.Number
+        && p.TryGetInt64(out var value)
+        && value > 0
+            ? value
+            : 0;
+
+    public SessionUsage GetUsage()
+    {
+        long input, output, cacheRead, cacheCreate, context;
+        string? modelId;
+
+        lock (_usageLock)
+        {
+            input = _inputTokens;
+            output = _outputTokens;
+            cacheRead = _cacheReadTokens;
+            cacheCreate = _cacheCreationTokens;
+            context = _contextTokens;
+            modelId = _modelId;
+        }
+
+        var (shortTotal, longTotal) = _usageLog.Totals(
+            ClaudeUsagePlanDefaults.ShortWindow, ClaudeUsagePlanDefaults.LongWindow);
+
+        return new SessionUsage
+        {
+            InputTokens = input,
+            OutputTokens = output,
+            CacheReadTokens = cacheRead,
+            CacheCreationTokens = cacheCreate,
+            ContextTokens = context,
+            ContextWindowTokens = ClaudeModelCatalog.ContextWindowFor(modelId),
+            ShortWindowTokens = shortTotal,
+            LongWindowTokens = longTotal,
+            ShortWindowBudget = _options.EffectiveFiveHourBudget,
+            LongWindowBudget = _options.EffectiveWeeklyBudget,
+            CostUsd = _cumulativeCostUsd > 0 ? _cumulativeCostUsd : null,
+            ModelId = modelId,
+        };
+    }
+
+    public event Action<SessionUsage>? UsageChanged;
+
+    private void RaiseUsageChanged()
+    {
+        var handler = UsageChanged;
+        if (handler is null) return;
+
+        try { handler(GetUsage()); }
+        catch (Exception ex)
+        {
+            // A crashing meter must not take the dispatcher loop down with it.
+            _logger.LogError(ex, "[ClaudeCli] UsageChanged handler threw");
+        }
+    }
+
+    public void ApplyModelAndEffort(string modelAlias, ClaudeEffort effort)
+    {
+        var alias = (modelAlias ?? "").Trim();
+        if (string.Equals(_options.Model, alias, StringComparison.OrdinalIgnoreCase)
+            && _options.Effort == effort)
+        {
+            return;
+        }
+
+        _options.Model = alias;
+        _options.Effort = effort;
+
+        // Both are start-up flags, so the running process cannot pick them up.
+        // Killing it here leaves _cliSessionId intact, which means the next
+        // SendMessageAsync starts a fresh process with --resume and the
+        // conversation carries on where it left off.
+        try
+        {
+            _host.Stop();
+            lock (_dispatcherLock) { _dispatcherTask = null; }
+            _logger.LogInformation(
+                "[ClaudeCli] Model/effort set to '{Model}'/'{Effort}'; process restarts on next message",
+                alias.Length == 0 ? "(cli default)" : alias, effort);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[ClaudeCli] Failed to stop CLI after a model/effort change");
+        }
+
+        RaiseUsageChanged();
+    }
+
     public void ClearHistory()
     {
         _cliSessionId = null;
         _cumulativeCostUsd = 0;
+
+        lock (_usageLock)
+        {
+            _inputTokens = _outputTokens = _cacheReadTokens = _cacheCreationTokens = 0;
+            _contextTokens = 0;
+            _countedMessageIds.Clear();
+            // _modelId survives: the next process reports it again on init, and
+            // keeping it means the context meter has a sane window in between.
+        }
+
         _host.Stop();
         lock (_dispatcherLock) { _dispatcherTask = null; }
         _logger.LogInformation("[ClaudeCli] Session cleared (process killed)");
+        RaiseUsageChanged();
     }
 
     public string SerializeHistory()

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliProcessHost.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliProcessHost.cs
@@ -188,6 +188,23 @@ public sealed class ClaudeCliProcessHost : IDisposable
         sb.Append(" --permission-mode ");
         sb.Append(permFlag);
 
+        // Model and effort are start-up flags, which is why changing either one
+        // in the header restarts this process.
+        //
+        // They are treated differently on purpose. An empty model leaves the
+        // flag off, because the CLI reports the model it settled on in its init
+        // event — the header can show the truth without us having to dictate it.
+        // Effort is never reported back, so it is always sent: that is the only
+        // way the dropdown can name a level that is genuinely in force.
+        if (!string.IsNullOrWhiteSpace(_options.Model))
+        {
+            sb.Append(" --model ");
+            sb.Append(EscapeArgument(_options.Model.Trim()));
+        }
+
+        sb.Append(" --effort ");
+        sb.Append(_options.Effort.ToCliValue());
+
         // Wire the MCP permission tool so the CLI asks us before running gated tools.
         // --strict-mcp-config prevents user-level MCP config from polluting the session.
         sb.Append(" --permission-prompt-tool mcp__vsagentic__approval_prompt");

--- a/src/VsAgentic.Services/ClaudeCli/UsageLog.cs
+++ b/src/VsAgentic.Services/ClaudeCli/UsageLog.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace VsAgentic.Services.ClaudeCli;
+
+/// <summary>
+/// Append-only record of "this many tokens went out at this time", used to fill
+/// the rolling 5-hour and weekly meters in the chat header.
+///
+/// It is deliberately machine-wide rather than per-session: the rate limit it
+/// approximates is charged against the account, so a meter that reset when a
+/// session closed — or when Visual Studio restarted — would flatter the user
+/// exactly when they most need the warning. That means the backing file is
+/// shared, possibly by two IDEs at once, so every operation here is best-effort
+/// and swallows its own IO errors. A missing or corrupt log costs a meter;
+/// it must never cost a message.
+/// </summary>
+public sealed class UsageLog
+{
+    private const string DirectoryName = "usage";
+    private const string FileName = "tokens.log";
+
+    /// <summary>
+    /// Entries older than this are dropped. Matches the longest window we
+    /// report, so the file stays proportional to what is actually readable
+    /// rather than growing for the life of the install.
+    /// </summary>
+    private static readonly TimeSpan Retention = TimeSpan.FromDays(7);
+
+    private static readonly Lazy<UsageLog> LazyShared = new(() => new UsageLog(DefaultPath()));
+
+    /// <summary>
+    /// Process-wide instance. Sessions each build their own DI container, so a
+    /// container singleton would give one log per session — the opposite of
+    /// what this type is for.
+    /// </summary>
+    public static UsageLog Shared => LazyShared.Value;
+
+    private readonly string _path;
+    private readonly object _gate = new();
+    private readonly List<Entry> _entries = new();
+    private bool _loaded;
+
+    /// <summary>
+    /// Last-write stamp of the file as of our last read. Comparing it on every
+    /// query is what lets a second Visual Studio instance's spending show up in
+    /// this one's meter without either polling or a file watcher.
+    /// </summary>
+    private DateTime _loadedStamp;
+
+    public UsageLog(string path)
+    {
+        _path = path;
+    }
+
+    private readonly struct Entry
+    {
+        public Entry(DateTime utc, long tokens)
+        {
+            Utc = utc;
+            Tokens = tokens;
+        }
+
+        public DateTime Utc { get; }
+        public long Tokens { get; }
+    }
+
+    private static string DefaultPath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "VsAgentic", DirectoryName, FileName);
+
+    /// <summary>
+    /// Notes tokens spent now. Zero and negative counts are ignored so a turn
+    /// that reported no usage cannot pad the log with empty rows.
+    /// </summary>
+    public void Record(long tokens) => Record(tokens, DateTime.UtcNow);
+
+    internal void Record(long tokens, DateTime utcNow)
+    {
+        if (tokens <= 0) return;
+
+        lock (_gate)
+        {
+            EnsureLoadedLocked(utcNow);
+            _entries.Add(new Entry(utcNow, tokens));
+            AppendLocked(utcNow, tokens);
+        }
+    }
+
+    /// <summary>
+    /// Tokens spent within the trailing <paramref name="shortWindow"/> and
+    /// <paramref name="longWindow"/>.
+    /// </summary>
+    public (long Short, long Long) Totals(TimeSpan shortWindow, TimeSpan longWindow) =>
+        Totals(shortWindow, longWindow, DateTime.UtcNow);
+
+    internal (long Short, long Long) Totals(TimeSpan shortWindow, TimeSpan longWindow, DateTime utcNow)
+    {
+        lock (_gate)
+        {
+            EnsureLoadedLocked(utcNow);
+
+            var shortCutoff = utcNow - shortWindow;
+            var longCutoff = utcNow - longWindow;
+
+            long shortTotal = 0, longTotal = 0;
+            foreach (var e in _entries)
+            {
+                if (e.Utc >= longCutoff) longTotal += e.Tokens;
+                if (e.Utc >= shortCutoff) shortTotal += e.Tokens;
+            }
+
+            return (shortTotal, longTotal);
+        }
+    }
+
+    private static DateTime WriteStamp(string path)
+    {
+        try { return File.Exists(path) ? File.GetLastWriteTimeUtc(path) : DateTime.MinValue; }
+        catch (Exception) { return DateTime.MinValue; }
+    }
+
+    private void EnsureLoadedLocked(DateTime utcNow)
+    {
+        var stamp = WriteStamp(_path);
+        if (_loaded && stamp == _loadedStamp) return;
+
+        _loaded = true;
+        _loadedStamp = stamp;
+        _entries.Clear();
+
+        try
+        {
+            if (!File.Exists(_path)) return;
+
+            var cutoff = utcNow - Retention;
+            var stale = false;
+
+            // Scoped, not a function-level `using`: the prune below deletes this
+            // very path, which cannot happen while we still hold it open.
+            using (var stream = new FileStream(
+                       _path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = new StreamReader(stream, Encoding.UTF8))
+            {
+                string? line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (!TryParse(line, out var entry))
+                    {
+                        // A torn last line is normal when another process is mid-append.
+                        continue;
+                    }
+
+                    if (entry.Utc < cutoff) { stale = true; continue; }
+                    _entries.Add(entry);
+                }
+            }
+
+            if (stale) RewriteLocked();
+        }
+        catch (Exception)
+        {
+            // An unreadable log means no meter, not a broken chat.
+            _entries.Clear();
+        }
+    }
+
+    private static bool TryParse(string line, out Entry entry)
+    {
+        entry = default;
+
+        var space = line.IndexOf(' ');
+        if (space <= 0) return false;
+
+        if (!long.TryParse(line.Substring(0, space), NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out var unixSeconds))
+            return false;
+        if (!long.TryParse(line.Substring(space + 1), NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out var tokens))
+            return false;
+        if (tokens <= 0) return false;
+
+        try
+        {
+            entry = new Entry(DateTimeOffset.FromUnixTimeSeconds(unixSeconds).UtcDateTime, tokens);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+
+    private static string Format(DateTime utc, long tokens) =>
+        new DateTimeOffset(utc, TimeSpan.Zero).ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture)
+        + " " + tokens.ToString(CultureInfo.InvariantCulture);
+
+    private void AppendLocked(DateTime utc, long tokens)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir!);
+
+            // One short line per append, so a concurrent writer interleaves
+            // whole rows rather than splitting one.
+            using (var stream = new FileStream(
+                _path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { NewLine = "\n" })
+            {
+                writer.WriteLine(Format(utc, tokens));
+            }
+
+            // Our own write must not look like someone else's, or the next
+            // query would re-read the whole file for nothing.
+            _loadedStamp = WriteStamp(_path);
+        }
+        catch (Exception)
+        {
+            // In-memory totals still work for this session.
+        }
+    }
+
+    private void RewriteLocked()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir!);
+
+            // Written to a sibling then moved, so a reader never observes a
+            // half-pruned file. Losing the race with another pruner is fine —
+            // both write the same surviving rows.
+            var temp = _path + ".tmp";
+            using (var stream = new FileStream(
+                temp, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { NewLine = "\n" })
+            {
+                foreach (var e in _entries)
+                    writer.WriteLine(Format(e.Utc, e.Tokens));
+            }
+
+            File.Delete(_path);
+            File.Move(temp, _path);
+            _loadedStamp = WriteStamp(_path);
+        }
+        catch (Exception)
+        {
+            // Pruning is housekeeping; failing it only means a larger file.
+        }
+    }
+}

--- a/src/VsAgentic.Services/Configuration/ClaudeModelCatalog.cs
+++ b/src/VsAgentic.Services/Configuration/ClaudeModelCatalog.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace VsAgentic.Services.Configuration;
+
+/// <summary>
+/// Reasoning effort for a session, mapping 1:1 onto the CLI's <c>--effort</c>
+/// levels.
+///
+/// There is deliberately no "default" member. The CLI does not report the
+/// effort it is running with — its <c>system/init</c> event names the model,
+/// the permission mode and the output style, but not this — so a "default"
+/// selection would be a value the header could never truthfully display. The
+/// extension therefore always passes the flag: whatever the dropdown shows is
+/// what the next turn will run with, by construction. The cost is that a level
+/// configured elsewhere in the user's own CLI settings is overridden.
+/// </summary>
+public enum ClaudeEffort
+{
+    Low,
+    Medium,
+    High,
+    XHigh,
+    Max,
+}
+
+public static class ClaudeEffortExtensions
+{
+    /// <summary>The spelling <c>--effort</c> expects.</summary>
+    public static string ToCliValue(this ClaudeEffort effort) => effort switch
+    {
+        ClaudeEffort.Low => "low",
+        ClaudeEffort.Medium => "medium",
+        ClaudeEffort.XHigh => "xhigh",
+        ClaudeEffort.Max => "max",
+        _ => "high",
+    };
+
+    /// <summary>Short label for the header dropdown.</summary>
+    public static string ToDisplayName(this ClaudeEffort effort) => effort switch
+    {
+        ClaudeEffort.Low => "Low",
+        ClaudeEffort.Medium => "Medium",
+        ClaudeEffort.XHigh => "XHigh",
+        ClaudeEffort.Max => "Max",
+        _ => "High",
+    };
+}
+
+/// <summary>
+/// One entry in the model dropdown. <see cref="Alias"/> is what goes to
+/// <c>--model</c>; an empty alias means "leave the CLI's own choice alone".
+/// </summary>
+public sealed class ClaudeModelInfo
+{
+    public ClaudeModelInfo(string alias, string displayName)
+    {
+        Alias = alias;
+        DisplayName = displayName;
+    }
+
+    public string Alias { get; }
+
+    public string DisplayName { get; }
+
+    public bool IsCliDefault => Alias.Length == 0;
+
+    public override string ToString() => DisplayName;
+}
+
+public static class ClaudeModelCatalog
+{
+    /// <summary>Context window every current model ships with by default.</summary>
+    public const int StandardContextWindowTokens = 200_000;
+
+    /// <summary>
+    /// Context window of the long-context variants, whose model ids carry a
+    /// <c>[1m]</c> suffix (e.g. <c>claude-opus-5[1m]</c>).
+    /// </summary>
+    public const int LongContextWindowTokens = 1_000_000;
+
+    /// <summary>
+    /// Aliases offered in the header dropdown. These are the aliases the CLI
+    /// documents for <c>--model</c>, which always resolve to the latest model
+    /// in each family — so this list does not need touching when a new model
+    /// ships.
+    /// </summary>
+    public static IReadOnlyList<ClaudeModelInfo> All { get; } = new[]
+    {
+        new ClaudeModelInfo("", "Default"),
+        new ClaudeModelInfo("opus", "Opus"),
+        new ClaudeModelInfo("sonnet", "Sonnet"),
+        new ClaudeModelInfo("haiku", "Haiku"),
+        new ClaudeModelInfo("fable", "Fable"),
+    };
+
+    public static ClaudeModelInfo Default => All[0];
+
+    /// <summary>
+    /// Resolves a stored alias back to its catalog entry, falling back to
+    /// <see cref="Default"/> so a stale or hand-edited setting cannot leave the
+    /// dropdown with nothing selected.
+    /// </summary>
+    public static ClaudeModelInfo Find(string? alias)
+    {
+        if (string.IsNullOrWhiteSpace(alias)) return Default;
+        return All.FirstOrDefault(m => string.Equals(m.Alias, alias, StringComparison.OrdinalIgnoreCase))
+            ?? Default;
+    }
+
+    /// <summary>
+    /// Context window for the concrete model id the CLI reports in its
+    /// <c>system/init</c> event. We read it off the id rather than the selected
+    /// alias because the alias resolves server-side — the init event is the
+    /// only place that names what is actually running.
+    /// </summary>
+    public static int ContextWindowFor(string? reportedModelId) =>
+        !string.IsNullOrEmpty(reportedModelId)
+        && reportedModelId!.IndexOf("[1m]", StringComparison.OrdinalIgnoreCase) >= 0
+            ? LongContextWindowTokens
+            : StandardContextWindowTokens;
+
+    /// <summary>
+    /// Turns a reported model id into something short enough for the header
+    /// ("claude-opus-5[1m]" → "Opus 5"). Unrecognized ids come back unchanged
+    /// so a new family still shows something truthful.
+    /// </summary>
+    public static string DisplayNameFor(string? reportedModelId)
+    {
+        if (string.IsNullOrWhiteSpace(reportedModelId)) return Default.DisplayName;
+
+        var id = reportedModelId!;
+
+        // Drop the context-window suffix and any date stamp, then title-case the
+        // family: "claude-opus-5[1m]" → "opus-5", "claude-haiku-4-5-20251001" → "haiku-4-5".
+        var bracket = id.IndexOf('[');
+        if (bracket > 0) id = id.Substring(0, bracket);
+        if (id.StartsWith("claude-", StringComparison.OrdinalIgnoreCase))
+            id = id.Substring("claude-".Length);
+
+        var parts = id.Split('-')
+            .Where(p => p.Length > 0 && !(p.Length == 8 && p.All(char.IsDigit)))
+            .ToArray();
+        if (parts.Length == 0) return reportedModelId!;
+
+        var family = parts[0];
+        family = char.ToUpperInvariant(family[0]) + family.Substring(1);
+        var version = string.Join(".", parts.Skip(1));
+
+        return version.Length == 0 ? family : family + " " + version;
+    }
+}

--- a/src/VsAgentic.Services/Configuration/ClaudeUsagePlan.cs
+++ b/src/VsAgentic.Services/Configuration/ClaudeUsagePlan.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace VsAgentic.Services.Configuration;
+
+/// <summary>
+/// The subscription the user is on. This exists only to size the rate-limit
+/// meter in the chat header — nothing here is sent to the CLI, and picking the
+/// wrong one changes no behaviour beyond how full that meter looks.
+/// </summary>
+public enum ClaudeUsagePlan
+{
+    Pro,
+    Max5x,
+    Max20x,
+
+    /// <summary>
+    /// No rolling cap worth drawing. Hides the 5-hour and weekly meters for
+    /// anyone who would rather not see an estimate at all.
+    /// </summary>
+    Unlimited,
+}
+
+/// <summary>
+/// Token budgets for the rolling usage windows.
+///
+/// IMPORTANT: Anthropic does not publish the token budget behind the 5-hour and
+/// weekly limits — the real limits are enforced server-side and vary with model
+/// and load. The numbers here are deliberate order-of-magnitude estimates so
+/// the meter conveys "barely started" vs "nearly out", and they are overridable
+/// via <see cref="VsAgenticOptions.FiveHourTokenBudget"/> and
+/// <see cref="VsAgenticOptions.WeeklyTokenBudget"/>. Treat the meter as a
+/// gauge, not as an authority — the CLI remains the only thing that knows when
+/// you have actually run out.
+/// </summary>
+public static class ClaudeUsagePlanDefaults
+{
+    public static readonly TimeSpan ShortWindow = TimeSpan.FromHours(5);
+    public static readonly TimeSpan LongWindow = TimeSpan.FromDays(7);
+
+    public static long ShortWindowTokens(ClaudeUsagePlan plan) => plan switch
+    {
+        ClaudeUsagePlan.Pro => 250_000,
+        ClaudeUsagePlan.Max5x => 1_250_000,
+        ClaudeUsagePlan.Max20x => 5_000_000,
+        _ => 0,
+    };
+
+    public static long LongWindowTokens(ClaudeUsagePlan plan) => plan switch
+    {
+        ClaudeUsagePlan.Pro => 2_500_000,
+        ClaudeUsagePlan.Max5x => 12_500_000,
+        ClaudeUsagePlan.Max20x => 50_000_000,
+        _ => 0,
+    };
+
+    public static string ToDisplayName(this ClaudeUsagePlan plan) => plan switch
+    {
+        ClaudeUsagePlan.Pro => "Pro",
+        ClaudeUsagePlan.Max5x => "Max 5x",
+        ClaudeUsagePlan.Max20x => "Max 20x",
+        _ => "Unlimited",
+    };
+}

--- a/src/VsAgentic.Services/Configuration/VsAgenticOptions.cs
+++ b/src/VsAgentic.Services/Configuration/VsAgenticOptions.cs
@@ -17,4 +17,45 @@ public class VsAgenticOptions
     /// or <see cref="CliPermissionMode.BypassPermissions"/> as escape hatches.
     /// </summary>
     public CliPermissionMode CliPermissionMode { get; set; } = CliPermissionMode.Default;
+
+    /// <summary>
+    /// Alias passed to the CLI's <c>--model</c>, or empty to leave the CLI's own
+    /// choice alone. Set from the model dropdown in the chat header; see
+    /// <see cref="ClaudeModelCatalog"/> for the accepted values.
+    /// </summary>
+    public string Model { get; set; } = "";
+
+    /// <summary>
+    /// Reasoning effort passed to the CLI's <c>--effort</c>, always sent so the
+    /// header can show a value that is actually in force. Set from the effort
+    /// dropdown in the chat header.
+    /// </summary>
+    public ClaudeEffort Effort { get; set; } = ClaudeEffort.High;
+
+    /// <summary>
+    /// Subscription the rolling usage meters are sized against. Display only —
+    /// nothing here reaches the CLI.
+    /// </summary>
+    public ClaudeUsagePlan UsagePlan { get; set; } = ClaudeUsagePlan.Pro;
+
+    /// <summary>
+    /// Overrides the 5-hour token budget implied by <see cref="UsagePlan"/>.
+    /// Zero keeps the plan default. This exists because the real limit is not
+    /// published and varies — see <see cref="ClaudeUsagePlanDefaults"/>.
+    /// </summary>
+    public long FiveHourTokenBudget { get; set; }
+
+    /// <summary>
+    /// Overrides the weekly token budget implied by <see cref="UsagePlan"/>.
+    /// Zero keeps the plan default.
+    /// </summary>
+    public long WeeklyTokenBudget { get; set; }
+
+    /// <summary>The 5-hour budget actually in force, after any override.</summary>
+    public long EffectiveFiveHourBudget =>
+        FiveHourTokenBudget > 0 ? FiveHourTokenBudget : ClaudeUsagePlanDefaults.ShortWindowTokens(UsagePlan);
+
+    /// <summary>The weekly budget actually in force, after any override.</summary>
+    public long EffectiveWeeklyBudget =>
+        WeeklyTokenBudget > 0 ? WeeklyTokenBudget : ClaudeUsagePlanDefaults.LongWindowTokens(UsagePlan);
 }

--- a/src/VsAgentic.UI/Controls/MinWidthVisibilityConverter.cs
+++ b/src/VsAgentic.UI/Controls/MinWidthVisibilityConverter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace VsAgentic.UI.Controls;
+
+/// <summary>
+/// Shows an element only once its container is at least
+/// <c>ConverterParameter</c> pixels wide.
+///
+/// A chat tool window is routinely docked at 300px and just as routinely
+/// floated at 1200px, so the header cannot assume room for everything. Rather
+/// than let the gauges squeeze the title into an ellipsis, each one names the
+/// width it needs and drops out below it — widest-to-narrowest, so what
+/// survives at the smallest size is what matters most.
+/// </summary>
+public sealed class MinWidthVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not double width || double.IsNaN(width))
+            return Visibility.Visible;
+
+        // During the first layout pass ActualWidth is 0; treating that as "too
+        // narrow" would collapse everything and, because collapsed children
+        // have no desired size, keep it collapsed.
+        if (width <= 0)
+            return Visibility.Visible;
+
+        return width >= Threshold(parameter) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private static double Threshold(object parameter) => parameter switch
+    {
+        double d => d,
+        string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) => v,
+        _ => 0d,
+    };
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.Usage.cs
+++ b/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.Usage.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Logging;
+using VsAgentic.Services.Abstractions;
+using VsAgentic.Services.Configuration;
+
+namespace VsAgentic.UI.ViewModels;
+
+/// <summary>
+/// The usage meters and the model / effort pickers shown in the chat header.
+///
+/// Split out from the main view model because it is a self-contained surface —
+/// nothing else in the session depends on it, and keeping it here leaves the
+/// conversation logic readable.
+/// </summary>
+public partial class ChatSessionViewModel
+{
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ContextDisplay))]
+    [NotifyPropertyChangedFor(nameof(ContextTooltip))]
+    [NotifyPropertyChangedFor(nameof(SessionTokensDisplay))]
+    [NotifyPropertyChangedFor(nameof(SessionTokensTooltip))]
+    [NotifyPropertyChangedFor(nameof(ShortWindowDisplay))]
+    [NotifyPropertyChangedFor(nameof(ShortWindowTooltip))]
+    [NotifyPropertyChangedFor(nameof(LongWindowDisplay))]
+    [NotifyPropertyChangedFor(nameof(LongWindowTooltip))]
+    [NotifyPropertyChangedFor(nameof(HasWindowMeters))]
+    [NotifyPropertyChangedFor(nameof(ModelDisplay))]
+    private SessionUsage _usage = SessionUsage.Empty;
+
+    // ── Model / effort pickers ────────────────────────────────────────────
+
+    /// <summary>
+    /// Per-session copies rather than the shared catalog, because the entry for
+    /// "whatever the CLI picks" relabels itself to the model that actually
+    /// turned up — and two sessions can be on different models.
+    /// </summary>
+    public IReadOnlyList<ModelOption> ModelOptions { get; } =
+        ClaudeModelCatalog.All.Select(m => new ModelOption(m)).ToList();
+
+    public IReadOnlyList<ClaudeEffort> EffortOptions { get; } =
+        (ClaudeEffort[])Enum.GetValues(typeof(ClaudeEffort));
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ModelDisplay))]
+    private ModelOption _selectedModel = null!;
+
+    [ObservableProperty]
+    private ClaudeEffort _selectedEffort = ClaudeEffort.High;
+
+    /// <summary>
+    /// Set while seeding the pickers from saved settings, so restoring a value
+    /// does not look like the user picking it and needlessly restart the CLI.
+    /// </summary>
+    private bool _suppressModelEffortApply;
+
+    /// <summary>
+    /// Raised when the user picks a model or effort, with the values to store.
+    /// The view model only holds them for the life of the session; making the
+    /// choice stick across restarts is the host's job, because only the host
+    /// knows where its settings live (the VS options page, in the extension's
+    /// case). Raised on the UI thread.
+    /// </summary>
+    public event Action<string, ClaudeEffort>? ModelEffortChanged;
+
+    partial void OnSelectedModelChanged(ModelOption value) => ApplyModelAndEffort();
+
+    partial void OnSelectedEffortChanged(ClaudeEffort value) => ApplyModelAndEffort();
+
+    private void ApplyModelAndEffort()
+    {
+        if (_suppressModelEffortApply || _chatService is null) return;
+
+        var alias = SelectedModel?.Alias ?? "";
+
+        try
+        {
+            _chatService.ApplyModelAndEffort(alias, SelectedEffort);
+        }
+        catch (Exception ex)
+        {
+            // A failed switch leaves the session on its current model, which is
+            // a working state — not worth tearing the UI down over.
+            _logger.LogError(ex, "[VM] Could not apply model/effort change");
+            return;
+        }
+
+        try { ModelEffortChanged?.Invoke(alias, SelectedEffort); }
+        catch (Exception ex) { _logger.LogError(ex, "[VM] ModelEffortChanged handler threw"); }
+    }
+
+    /// <summary>
+    /// Seeds the pickers from saved settings and starts tracking usage.
+    /// Called from the constructor once the chat service is known.
+    /// </summary>
+    private void InitializeUsage(IChatService chatService, VsAgenticOptions options)
+    {
+        _suppressModelEffortApply = true;
+        try
+        {
+            var alias = ClaudeModelCatalog.Find(options.Model).Alias;
+            SelectedModel = ModelOptions.FirstOrDefault(
+                m => string.Equals(m.Alias, alias, StringComparison.OrdinalIgnoreCase))
+                ?? ModelOptions[0];
+            SelectedEffort = options.Effort;
+        }
+        finally
+        {
+            _suppressModelEffortApply = false;
+        }
+
+        chatService.UsageChanged += OnChatServiceUsageChanged;
+        Usage = chatService.GetUsage();
+        RefreshResolvedModelLabel();
+    }
+
+    private void OnChatServiceUsageChanged(SessionUsage usage) => Dispatch(() =>
+    {
+        Usage = usage;
+        RefreshResolvedModelLabel();
+    });
+
+    /// <summary>
+    /// Relabels the "let the CLI decide" entry to the model that actually
+    /// turned up, so the dropdown reads "Opus 5" rather than "Default". The
+    /// other entries are fixed aliases and already say what they mean.
+    /// </summary>
+    private void RefreshResolvedModelLabel()
+    {
+        var resolved = Usage.ModelId is { Length: > 0 }
+            ? ClaudeModelCatalog.DisplayNameFor(Usage.ModelId)
+            : null;
+
+        foreach (var option in ModelOptions)
+        {
+            if (option.IsCliDefault)
+                option.DisplayName = resolved ?? ModelOption.PendingLabel;
+        }
+    }
+
+    // ── Header text ───────────────────────────────────────────────────────
+
+    /// <summary>What the model chip shows: what is actually running, when the CLI has said.</summary>
+    public string ModelDisplay => Usage.ModelId is { Length: > 0 }
+        ? ClaudeModelCatalog.DisplayNameFor(Usage.ModelId)
+        : SelectedModel?.DisplayName ?? ClaudeModelCatalog.Default.DisplayName;
+
+    public string ContextDisplay =>
+        $"{FormatTokens(Usage.ContextTokens)} / {FormatTokens(Usage.ContextWindowTokens)}";
+
+    public string ContextTooltip =>
+        "Context window\n"
+        + $"Used: {FormatExact(Usage.ContextTokens)} of {FormatExact(Usage.ContextWindowTokens)} tokens "
+        + $"({Usage.ContextFraction:P0})\n"
+        + "How full the model's context is right now. This falls back down when the conversation is compacted.";
+
+    public string SessionTokensDisplay => FormatTokens(Usage.TotalTokens);
+
+    public string SessionTokensTooltip =>
+        "This session\n"
+        + $"Input: {FormatExact(Usage.InputTokens)}\n"
+        + $"Output: {FormatExact(Usage.OutputTokens)}\n"
+        + $"Cache read: {FormatExact(Usage.CacheReadTokens)}\n"
+        + $"Cache write: {FormatExact(Usage.CacheCreationTokens)}\n"
+        + $"Total: {FormatExact(Usage.TotalTokens)} tokens"
+        + (Usage.CostUsd is { } cost ? $"\nCost: {cost.ToString("C2", CultureInfo.GetCultureInfo("en-US"))}" : "");
+
+    public bool HasWindowMeters => Usage.HasWindowBudget;
+
+    // The window meters carry their own prefix because the bars no longer have
+    // captions above them — inside the bar is the only place left to say which
+    // window this is.
+    public string ShortWindowDisplay => "5h " + FormatBudget(Usage.ShortWindowTokens, Usage.ShortWindowBudget);
+
+    public string ShortWindowTooltip => WindowTooltip(
+        "Last 5 hours", Usage.ShortWindowTokens, Usage.ShortWindowBudget, Usage.ShortWindowFraction);
+
+    public string LongWindowDisplay => "7d " + FormatBudget(Usage.LongWindowTokens, Usage.LongWindowBudget);
+
+    public string LongWindowTooltip => WindowTooltip(
+        "Last 7 days", Usage.LongWindowTokens, Usage.LongWindowBudget, Usage.LongWindowFraction);
+
+    private static string WindowTooltip(string title, long used, long budget, double fraction) =>
+        title + "\n"
+        + $"Used: {FormatExact(used)} of about {FormatExact(budget)} tokens ({fraction:P0})\n"
+        + "Counted across every VsAgentic session on this machine, and kept between restarts.\n"
+        + "The budget is an estimate — Anthropic does not publish the real limit, so treat this "
+        + "as a gauge rather than an authority. Adjust it under Tools → Options → VsAgentic.";
+
+    // ── Formatting ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Compact form for the header, where width is scarce: 950, 12.3k, 1.2M.
+    /// </summary>
+    private static string FormatTokens(long tokens)
+    {
+        if (tokens <= 0) return "0";
+        if (tokens < 1_000) return tokens.ToString(CultureInfo.InvariantCulture);
+
+        if (tokens < 1_000_000)
+        {
+            var thousands = tokens / 1_000d;
+            // Two significant-ish digits under 10k, none above: "9.4k", "127k".
+            return thousands < 10
+                ? thousands.ToString("0.#", CultureInfo.InvariantCulture) + "k"
+                : Math.Round(thousands).ToString("0", CultureInfo.InvariantCulture) + "k";
+        }
+
+        var millions = tokens / 1_000_000d;
+        return millions < 10
+            ? millions.ToString("0.##", CultureInfo.InvariantCulture) + "M"
+            : Math.Round(millions).ToString("0", CultureInfo.InvariantCulture) + "M";
+    }
+
+    /// <summary>Grouped digits for tooltips, where the exact number is the point.</summary>
+    private static string FormatExact(long tokens) =>
+        tokens.ToString("N0", CultureInfo.InvariantCulture);
+
+    private static string FormatBudget(long used, long budget) =>
+        budget > 0
+            ? $"{FormatTokens(used)} / {FormatTokens(budget)}"
+            : FormatTokens(used);
+}
+
+/// <summary>
+/// One row of the model dropdown. A view-model type rather than the plain
+/// <see cref="ClaudeModelInfo"/> because the "let the CLI decide" row renames
+/// itself once the CLI says what it picked, and that has to raise a change
+/// notification for the dropdown to redraw.
+/// </summary>
+public partial class ModelOption : ObservableObject
+{
+    /// <summary>
+    /// Shown until the first turn reveals the real model. "Auto" rather than
+    /// "Default" because it describes who is choosing without naming a value we
+    /// do not yet know.
+    /// </summary>
+    public const string PendingLabel = "Auto";
+
+    public ModelOption(ClaudeModelInfo info)
+    {
+        Alias = info.Alias;
+        _displayName = info.IsCliDefault ? PendingLabel : info.DisplayName;
+    }
+
+    public string Alias { get; }
+
+    public bool IsCliDefault => Alias.Length == 0;
+
+    [ObservableProperty]
+    private string _displayName;
+
+    public override string ToString() => DisplayName;
+}

--- a/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
@@ -174,6 +174,8 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             _questionBroker.QuestionRequested += OnQuestionBrokerRequested;
 
         chatService.LoginRequired += OnChatServiceLoginRequired;
+
+        InitializeUsage(chatService, options.Value);
     }
 
     private void OnChatServiceLoginRequired(string? errorMessage)
@@ -708,6 +710,12 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         try { _activityTimer?.Stop(); } catch { }
+        try
+        {
+            if (_chatService is not null)
+                _chatService.UsageChanged -= OnChatServiceUsageChanged;
+        }
+        catch { }
         try { (_chatService as IDisposable)?.Dispose(); } catch { }
         try { _serviceScope?.Dispose(); } catch { }
     }

--- a/src/VsAgentic.VSExtension/Options/VsAgenticOptionsPage.cs
+++ b/src/VsAgentic.VSExtension/Options/VsAgenticOptionsPage.cs
@@ -25,6 +25,36 @@ public class VsAgenticOptionsPage : DialogPage
     [DefaultValue(CliPermissionMode.Default)]
     public CliPermissionMode CliPermissionMode { get; set; } = CliPermissionMode.Default;
 
+    [Category("Claude CLI")]
+    [DisplayName("Model")]
+    [Description("Model alias passed to the CLI (opus, sonnet, haiku, fable), or empty to leave the CLI's own choice alone. Normally set from the dropdown in the chat header; this is where that choice is remembered between restarts.")]
+    [DefaultValue("")]
+    public string Model { get; set; } = "";
+
+    [Category("Claude CLI")]
+    [DisplayName("Reasoning effort")]
+    [Description("Effort level passed to the CLI on every session. Always sent, because the CLI does not report the effort it is running with — sending it is the only way the header can name a level that is genuinely in force. Note this overrides an effort configured elsewhere in your own CLI settings. Normally set from the dropdown in the chat header.")]
+    [DefaultValue(ClaudeEffort.High)]
+    public ClaudeEffort Effort { get; set; } = ClaudeEffort.High;
+
+    [Category("Usage meters")]
+    [DisplayName("Plan")]
+    [Description("Subscription the 5-hour and weekly meters in the chat header are sized against. Display only — nothing here is sent to the CLI. Choose Unlimited to hide those meters.")]
+    [DefaultValue(ClaudeUsagePlan.Pro)]
+    public ClaudeUsagePlan UsagePlan { get; set; } = ClaudeUsagePlan.Pro;
+
+    [Category("Usage meters")]
+    [DisplayName("5-hour token budget")]
+    [Description("Overrides the 5-hour budget implied by the plan. 0 keeps the plan default. Anthropic does not publish the real limit, so the built-in numbers are estimates — set this if you have measured your own.")]
+    [DefaultValue(0L)]
+    public long FiveHourTokenBudget { get; set; }
+
+    [Category("Usage meters")]
+    [DisplayName("Weekly token budget")]
+    [Description("Overrides the weekly budget implied by the plan. 0 keeps the plan default.")]
+    [DefaultValue(0L)]
+    public long WeeklyTokenBudget { get; set; }
+
     [Category("Sessions")]
     [DisplayName("Keep days of activity")]
     [Description("When the extension starts, sessions whose last activity is older than this many days are deleted. Default: 30. Set to 0 to disable cleanup.")]

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
@@ -6,10 +6,122 @@
              xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              xmlns:controls="clr-namespace:VsAgentic.UI.Controls;assembly=VsAgentic.UI"
              xmlns:bvm="clr-namespace:VsAgentic.UI.ViewModels.Banners;assembly=VsAgentic.UI"
-             xmlns:bv="clr-namespace:VsAgentic.VSExtension.ToolWindows.Banners" >
+             xmlns:bv="clr-namespace:VsAgentic.VSExtension.ToolWindows.Banners"
+             xmlns:local="clr-namespace:VsAgentic.VSExtension.ToolWindows" >
 
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <controls:MinWidthVisibilityConverter x:Key="MinWidth"/>
+
+        <!-- Header pickers. Fully retemplated rather than merely unbordered:
+             the stock ComboBox chrome draws its own border, background and
+             focus ring, none of which BorderThickness="0" removes. What is left
+             is the label plus a chevron, with a hover fill borrowed from the
+             command bar so it still reads as clickable. -->
+        <Style x:Key="HeaderComboStyle" TargetType="ComboBox">
+            <Setter Property="Margin" Value="4,0,0,0"/>
+            <Setter Property="Padding" Value="6,0"/>
+            <Setter Property="Height" Value="19"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Foreground"
+                    Value="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <!-- Foreground is forwarded explicitly. ToggleButton's
+                                 own default style sets it to the system control
+                                 text colour, and a style setter beats an
+                                 inherited value, so without this local value the
+                                 label renders near-black on a dark theme no
+                                 matter what the ComboBox says. -->
+                            <ToggleButton x:Name="Toggle"
+                                          Focusable="False"
+                                          ClickMode="Press"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                                <ToggleButton.Template>
+                                    <ControlTemplate TargetType="ToggleButton">
+                                        <Border x:Name="Chrome"
+                                                Background="Transparent"
+                                                CornerRadius="3"
+                                                SnapsToDevicePixels="True">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <ContentPresenter Grid.Column="0"
+                                                                  Margin="6,0,2,0"
+                                                                  VerticalAlignment="Center"
+                                                                  Content="{Binding SelectionBoxItem, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                                  ContentTemplate="{Binding SelectionBoxItemTemplate, RelativeSource={RelativeSource AncestorType=ComboBox}}"/>
+                                                <Path Grid.Column="1"
+                                                      Margin="0,1,6,0"
+                                                      VerticalAlignment="Center"
+                                                      Data="M 0 0 L 3.5 3.5 L 7 0 Z"
+                                                      Fill="{DynamicResource {x:Static vs:VsBrushes.GrayTextKey}}"/>
+                                            </Grid>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Chrome" Property="Background"
+                                                        Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMouseOverBackgroundGradientKey}}"/>
+                                            </Trigger>
+                                            <Trigger Property="IsChecked" Value="True">
+                                                <Setter TargetName="Chrome" Property="Background"
+                                                        Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMouseDownBackgroundGradientKey}}"/>
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                            </ToggleButton>
+
+                            <Popup IsOpen="{TemplateBinding IsDropDownOpen}"
+                                   Placement="Bottom"
+                                   AllowsTransparency="True"
+                                   PopupAnimation="Fade"
+                                   Focusable="False">
+                                <Border Background="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBackgroundKey}}"
+                                        BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
+                                        BorderThickness="1"
+                                        CornerRadius="3"
+                                        MinWidth="{TemplateBinding ActualWidth}"
+                                        SnapsToDevicePixels="True">
+                                    <ItemsPresenter/>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="HeaderComboItemStyle" TargetType="ComboBoxItem">
+            <Setter Property="Padding" Value="8,3"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground"
+                    Value="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBoxItem">
+                        <Border x:Name="ItemChrome"
+                                Background="Transparent"
+                                Padding="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsHighlighted" Value="True">
+                                <Setter TargetName="ItemChrome" Property="Background"
+                                        Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMouseOverBackgroundGradientKey}}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
 
         <!-- Banner DataTemplates: ContentControl below picks the right view by VM type. -->
         <DataTemplate DataType="{x:Type bvm:PermissionBannerViewModel}">
@@ -110,6 +222,88 @@
 
     <DockPanel x:Name="RootPanel"
                Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}">
+
+        <!-- Header: usage gauges and the model / effort pickers, right-aligned.
+             No title here on purpose — the tool window caption immediately above
+             already carries it, spinner and all, and repeating it would waste
+             the one row this strip is allowed. The empty left half is what lets
+             the gauges keep their place as the pane is resized.
+
+             Each gauge names the header width it needs and drops out below it,
+             so a narrowly docked window keeps the pickers rather than four
+             squeezed bars. -->
+        <Border DockPanel.Dock="Top"
+                x:Name="HeaderBar"
+                Background="{DynamicResource {x:Static vs:VsBrushes.CommandBarGradientBeginKey}}"
+                BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBorderKey}}"
+                BorderThickness="0,0,0,1"
+                Padding="8,3">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="0"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center">
+
+                    <!-- Weekly first in the markup but widest-gated, so the
+                         gauges disappear right-to-left as the window narrows.
+                         The thresholds are far lower than the captioned layout
+                         needed: the reading now sits inside the bar, so each
+                         gauge costs roughly its own text. -->
+                    <StackPanel Orientation="Horizontal"
+                                Visibility="{Binding HasWindowMeters, Converter={StaticResource BoolToVis}}">
+                        <local:UsageMeter ValueText="{Binding LongWindowDisplay}"
+                                          Fraction="{Binding Usage.LongWindowFraction}"
+                                          Level="{Binding Usage.LongWindowLevel}"
+                                          ToolTip="{Binding LongWindowTooltip}"
+                                          Visibility="{Binding ActualWidth, ElementName=HeaderBar,
+                                                       Converter={StaticResource MinWidth},
+                                                       ConverterParameter=470}"/>
+                        <local:UsageMeter ValueText="{Binding ShortWindowDisplay}"
+                                          Fraction="{Binding Usage.ShortWindowFraction}"
+                                          Level="{Binding Usage.ShortWindowLevel}"
+                                          ToolTip="{Binding ShortWindowTooltip}"
+                                          Visibility="{Binding ActualWidth, ElementName=HeaderBar,
+                                                       Converter={StaticResource MinWidth},
+                                                       ConverterParameter=340}"/>
+                    </StackPanel>
+
+                    <local:UsageMeter Caption="Session"
+                                      ValueText="{Binding SessionTokensDisplay}"
+                                      ShowBar="False"
+                                      ToolTip="{Binding SessionTokensTooltip}"
+                                      Visibility="{Binding ActualWidth, ElementName=HeaderBar,
+                                                   Converter={StaticResource MinWidth},
+                                                   ConverterParameter=600}"/>
+
+                    <local:UsageMeter ValueText="{Binding ContextDisplay}"
+                                      Fraction="{Binding Usage.ContextFraction}"
+                                      Level="{Binding Usage.ContextLevel}"
+                                      ToolTip="{Binding ContextTooltip}"
+                                      Visibility="{Binding ActualWidth, ElementName=HeaderBar,
+                                                   Converter={StaticResource MinWidth},
+                                                   ConverterParameter=210}"/>
+
+                    <!-- Changing either picker restarts the CLI process on the
+                         next message; the conversation is resumed, not lost. -->
+                    <ComboBox Style="{StaticResource HeaderComboStyle}"
+                              ItemContainerStyle="{StaticResource HeaderComboItemStyle}"
+                              ItemsSource="{Binding ModelOptions}"
+                              SelectedItem="{Binding SelectedModel}"
+                              DisplayMemberPath="DisplayName"
+                              ToolTip="{Binding ModelDisplay, StringFormat='Model: {0}&#x0a;Takes effect on the next message.'}"/>
+
+                    <ComboBox Style="{StaticResource HeaderComboStyle}"
+                              ItemContainerStyle="{StaticResource HeaderComboItemStyle}"
+                              ItemsSource="{Binding EffortOptions}"
+                              SelectedItem="{Binding SelectedEffort}"
+                              ToolTip="Reasoning effort.&#x0a;Takes effect on the next message."/>
+                </StackPanel>
+            </Grid>
+        </Border>
 
         <!-- Input Area -->
         <Border DockPanel.Dock="Bottom"

--- a/src/VsAgentic.VSExtension/ToolWindows/UsageMeter.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/UsageMeter.xaml
@@ -1,0 +1,112 @@
+<UserControl x:Class="VsAgentic.VSExtension.ToolWindows.UsageMeter"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:platformui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             x:Name="Root">
+
+    <UserControl.Resources>
+        <!-- Flat, filled pill. The default ProgressBar chrome carries a border,
+             a gradient and an animation that all read as "work in progress";
+             this is a level gauge, so it gets none of them. PART_Track and
+             PART_Indicator keep the stock sizing logic working.
+
+             The fill is deliberately translucent: the reading sits on top of
+             the bar, and it has to stay legible across the boundary between the
+             filled and unfilled halves. -->
+        <Style x:Key="MeterBarStyle" TargetType="ProgressBar">
+            <Setter Property="Minimum" Value="0"/>
+            <Setter Property="Maximum" Value="1"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Background"
+                    Value="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"/>
+            <!-- Normal: the hyperlink colour the chat already uses as its accent,
+                 so the header agrees with the transcript below it. -->
+            <Setter Property="Foreground"
+                    Value="{DynamicResource {x:Static vs:VsBrushes.PanelHyperlinkKey}}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ProgressBar">
+                        <Border CornerRadius="3"
+                                Background="{TemplateBinding Background}"
+                                SnapsToDevicePixels="True"
+                                ClipToBounds="True">
+                            <Grid>
+                                <Rectangle x:Name="PART_Track"/>
+                                <Rectangle x:Name="PART_Indicator"
+                                           HorizontalAlignment="Left"
+                                           RadiusX="3" RadiusY="3"
+                                           Opacity="0.45"
+                                           Fill="{TemplateBinding Foreground}"/>
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <!-- UsageWarningBrush is themed in code-behind: VS ships no
+                     semantic "warning" brush, so it is derived from the current
+                     theme's background instead of hard-coded. -->
+                <DataTrigger Binding="{Binding Level, ElementName=Root}" Value="Warning">
+                    <Setter Property="Foreground" Value="{DynamicResource UsageWarningBrush}"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Level, ElementName=Root}" Value="Critical">
+                    <Setter Property="Foreground"
+                            Value="{DynamicResource {x:Static platformui:EnvironmentColors.ToolWindowValidationErrorTextBrushKey}}"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid VerticalAlignment="Center" Margin="0,0,8,0">
+        <!-- Gauge form: the reading lives inside the bar, so no caption above
+             and no wasted vertical space. -->
+        <Grid x:Name="BarForm" MinWidth="66">
+            <Grid.Style>
+                <Style TargetType="Grid">
+                    <Setter Property="Visibility" Value="Visible"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ShowBar, ElementName=Root}" Value="False">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Style>
+            <ProgressBar Style="{StaticResource MeterBarStyle}"
+                         Height="17"
+                         Value="{Binding Fraction, ElementName=Root}"/>
+            <TextBlock Text="{Binding ValueText, ElementName=Root}"
+                       Margin="8,0"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       FontSize="10"
+                       Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
+        </Grid>
+
+        <!-- Plain form, for readings with no ceiling: a bar pinned at zero
+             forever reads as broken, not as unbounded. -->
+        <StackPanel x:Name="TextForm"
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ShowBar, ElementName=Root}" Value="False">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBlock Text="{Binding Caption, ElementName=Root}"
+                       VerticalAlignment="Center"
+                       FontSize="10"
+                       Foreground="{DynamicResource {x:Static vs:VsBrushes.GrayTextKey}}"/>
+            <TextBlock Text="{Binding ValueText, ElementName=Root}"
+                       Margin="5,0,0,0"
+                       VerticalAlignment="Center"
+                       FontSize="10"
+                       Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/VsAgentic.VSExtension/ToolWindows/UsageMeter.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/UsageMeter.xaml.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Microsoft.VisualStudio.PlatformUI;
+using VsAgentic.Services.Abstractions;
+
+namespace VsAgentic.VSExtension.ToolWindows;
+
+/// <summary>
+/// One labelled gauge in the chat header: a caption, a reading, and a thin bar
+/// that changes colour as it fills.
+/// </summary>
+public partial class UsageMeter : UserControl
+{
+    public UsageMeter()
+    {
+        InitializeComponent();
+
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    public static readonly DependencyProperty CaptionProperty =
+        DependencyProperty.Register(nameof(Caption), typeof(string), typeof(UsageMeter),
+            new PropertyMetadata(""));
+
+    /// <summary>Short label above the bar, e.g. "Context".</summary>
+    public string Caption
+    {
+        get => (string)GetValue(CaptionProperty);
+        set => SetValue(CaptionProperty, value);
+    }
+
+    public static readonly DependencyProperty ValueTextProperty =
+        DependencyProperty.Register(nameof(ValueText), typeof(string), typeof(UsageMeter),
+            new PropertyMetadata(""));
+
+    /// <summary>The reading itself, e.g. "128k / 200k". Pre-formatted by the view model.</summary>
+    public string ValueText
+    {
+        get => (string)GetValue(ValueTextProperty);
+        set => SetValue(ValueTextProperty, value);
+    }
+
+    public static readonly DependencyProperty FractionProperty =
+        DependencyProperty.Register(nameof(Fraction), typeof(double), typeof(UsageMeter),
+            new PropertyMetadata(0d));
+
+    /// <summary>How full the bar is, 0 to 1. Already clamped by <see cref="SessionUsage"/>.</summary>
+    public double Fraction
+    {
+        get => (double)GetValue(FractionProperty);
+        set => SetValue(FractionProperty, value);
+    }
+
+    public static readonly DependencyProperty LevelProperty =
+        DependencyProperty.Register(nameof(Level), typeof(UsageLevel), typeof(UsageMeter),
+            new PropertyMetadata(UsageLevel.Normal));
+
+    /// <summary>Drives the bar colour; see the triggers in the XAML.</summary>
+    public UsageLevel Level
+    {
+        get => (UsageLevel)GetValue(LevelProperty);
+        set => SetValue(LevelProperty, value);
+    }
+
+    public static readonly DependencyProperty ShowBarProperty =
+        DependencyProperty.Register(nameof(ShowBar), typeof(bool), typeof(UsageMeter),
+            new PropertyMetadata(true));
+
+    /// <summary>
+    /// False for readings with no ceiling — session totals only ever grow, so
+    /// there is no fraction to draw.
+    /// </summary>
+    public bool ShowBar
+    {
+        get => (bool)GetValue(ShowBarProperty);
+        set => SetValue(ShowBarProperty, value);
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ApplyWarningBrush();
+        VSColorTheme.ThemeChanged += OnThemeChanged;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        // VSColorTheme is a shell-lifetime static, so a meter that forgot to
+        // detach would keep this control (and the whole session) alive.
+        VSColorTheme.ThemeChanged -= OnThemeChanged;
+    }
+
+    private void OnThemeChanged(ThemeChangedEventArgs e) =>
+        Dispatcher.BeginInvoke(new Action(ApplyWarningBrush));
+
+    /// <summary>
+    /// Visual Studio exposes no semantic "warning" brush — only a validation
+    /// error one — so the amber is picked here against the current theme rather
+    /// than hard-coded: a single value legible on both Dark and Light does not
+    /// exist.
+    /// </summary>
+    private void ApplyWarningBrush()
+    {
+        try
+        {
+            var background = VSColorTheme.GetThemedColor(
+                EnvironmentColors.ToolWindowBackgroundColorKey);
+
+            var amber = IsDark(background)
+                ? Color.FromRgb(0xE0, 0xA3, 0x3E)   // lifted, for dark backgrounds
+                : Color.FromRgb(0xA9, 0x6A, 0x00);  // deepened, for light ones
+
+            var brush = new SolidColorBrush(amber);
+            brush.Freeze();
+            Resources["UsageWarningBrush"] = brush;
+        }
+        catch (Exception)
+        {
+            // Falling back to the accent colour costs a shade of meaning, not
+            // the meter — and never the chat.
+        }
+    }
+
+    /// <summary>
+    /// Rec. 601 luma. Takes a <see cref="System.Drawing.Color"/> because that is
+    /// what <see cref="VSColorTheme.GetThemedColor"/> hands back — WPF's own
+    /// Color type is a different struct.
+    /// </summary>
+    private static bool IsDark(System.Drawing.Color c) =>
+        (0.299 * c.R + 0.587 * c.G + 0.114 * c.B) < 128;
+}

--- a/src/VsAgentic.VSExtension/VsAgenticPackage.cs
+++ b/src/VsAgentic.VSExtension/VsAgenticPackage.cs
@@ -178,6 +178,11 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
             {
                 options.ClaudeCliPath = optionsPage.ClaudeCliPath;
                 options.CliPermissionMode = optionsPage.CliPermissionMode;
+                options.Model = optionsPage.Model;
+                options.Effort = optionsPage.Effort;
+                options.UsagePlan = optionsPage.UsagePlan;
+                options.FiveHourTokenBudget = optionsPage.FiveHourTokenBudget;
+                options.WeeklyTokenBudget = optionsPage.WeeklyTokenBudget;
             }
         });
 
@@ -189,6 +194,27 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
         var vmLogger = provider.GetService<Microsoft.Extensions.Logging.ILogger<ChatSessionViewModel>>();
 
         var vm = new ChatSessionViewModel(chatService, outputListener, optionsAccessor, permissionBroker, questionBroker, vmLogger);
+
+        // The header pickers only change this session; persisting the choice so
+        // the next one starts the same way is the host's side of the deal.
+        if (optionsPage is not null)
+        {
+            vm.ModelEffortChanged += (alias, effort) =>
+            {
+                try
+                {
+                    optionsPage.Model = alias;
+                    optionsPage.Effort = effort;
+                    optionsPage.SaveSettingsToStorage();
+                }
+                catch (Exception ex)
+                {
+                    // Worst case the choice is forgotten at the next restart.
+                    Log.Warning(ex, "Could not persist the model/effort choice");
+                }
+            };
+        }
+
         vm.SetServiceScope(provider);
         return vm;
     }


### PR DESCRIPTION
Fixes #30
Fixes #5

### Change

The status bar under the chat input now shows four readings and two dropdowns: 7d, 5h, session tokens, context, model and effort. They fill the `StatusInfo` cell between the `@` button and Send, which was reserved and unused. There is no header, so the chat keeps its full height.

**Narrow pane.** Each item names the cell width it needs and drops out below it. The order is effort, model, Session, 7d, 5h. Context is the last to go: it is ambient, and hidden it cannot warn that a compaction is near. The dropdowns are occasional actions, and widening the pane or Tools → Options reaches them again.

**Reading the numbers.** Usage is folded in from the `usage` block on each assistant event, not from the turn-level aggregate on the result event — taking both would double-count. Messages are counted per `id`, because the CLI can emit several assistant events sharing one message id with the usage block repeated verbatim. A message with no id is counted anyway: a small overcount beats dropping usage that was genuinely incurred.

**Context.** Occupancy is assigned rather than accumulated, so it drops back down after a compaction. Its ceiling comes from the model id, and only the id the CLI reports in `system/init` carries the `[1m]` suffix, so a 1M session reads `35k / 1M`. Cache reads count in full here, since they occupy the window. Context is the only reading with a bar, because its ceiling is real.

**The rolling windows.** 5h and 7d are plain text, `5h 5.2M / ~250k`. Their budgets are estimates, and a bar would claim a proportion against a known ceiling; the tilde marks the budget as the estimate. They are backed by an append-only log under `%AppData%\VsAgentic\usage`, one short line per turn. It is machine-wide on purpose: the limit it approximates is charged against the account, so a reading that reset when a session closed would flatter the user exactly when the warning is worth having. Two IDEs can append to it at once, so the file is opened share-all, torn lines are skipped, old entries are pruned, and every operation swallows its own IO errors. Cache reads are weighted at a tenth in this log, matching the published billing ratio.

**Model.** The value comes from `IChatService.CurrentModel` and `ModelChanged`. The CLI emits `system/init` with the first message, not at process start, and every way of forcing it earlier costs an API call. So before the first turn the view model shows a preview from `ClaudeModelResolver`, which reads the same files the CLI does. `--resume` keeps a session on the model it was created with, so a restored session reads its CLI transcript, and only a new session reads the configured default. The session history also stores the reported model, because the transcript names the bare model without `[1m]`.

`ClaudeModelResolver` and this approach come from #15 by @fromorbonia, which was closed as stale; @adospace asked for the approach to be carried over. Two additions: transcript entries with the model `<synthetic>` are skipped, and the reported model is persisted with the session.

**Model and effort dropdowns.** Both are start-up flags, so changing either stops the process; `_cliSessionId` survives, and the next message starts a fresh process with `--resume`. Each flag is sent only when the user picks a value. With the model left to the CLI, the dropdown's first row shows the resolved model, for example `Opus 5`.

**Theming.** Everything resolves through `VsBrushes` and `EnvironmentColors`. VS ships no semantic warning brush, so the amber for the context bar's warning state is derived in code-behind from the current theme's background luminance and refreshed on `ThemeChanged`. The bar's track uses a faint wash of the grey text colour, not `ComboBoxBorderKey`, which already draws the input container and the rule above the status bar.

### Trade-off worth naming

Effort `Default` sends no `--effort`, so a CLI older than that flag still starts. The CLI does not report the effort it runs with, so the dropdown then says `Default` rather than a level.

When no settings file names a model, a new session shows `Default` until the first turn. The account default cannot be read without an API call.

The 5h and 7d budgets are estimates, seeded per plan and overridable in the options page. Setting **Plan** to `Unlimited` hides both readings.

### Not included

No cost figure in the status bar — it is in the session tooltip only.

Session totals and context occupancy are not persisted. A restored session reads `Session 0` and `0 / 200k` until its first turn.

The Desktop host is unchanged; this is the VS extension only.

### Verified

See the comments below for the latest manual test in the experimental instance, checked against the extension log and the CLI transcript.

No version bump included, same as the other PRs.
