### PR TITLE
Scope the ANTHROPIC_API_KEY override to the processes it is meant for

### DIFF
--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliChatService.cs
@@ -63,10 +63,24 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
         _outputListener = outputListener;
         _host = host;
         _logger = logger;
+    }
 
-        // Strip any inherited API key from the host process so child CLI uses
-        // subscription auth.
-        Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", null);
+    /// <summary>
+    /// Keeps an inherited <c>ANTHROPIC_API_KEY</c> out of a CLI we are about to
+    /// start, so it authenticates against the subscription rather than billing
+    /// the key at API rates.
+    ///
+    /// Applied per child process. Clearing it on the host instead would reach
+    /// far further than intended: the variable would vanish from Visual Studio
+    /// itself and from everything else it launches for the rest of the session,
+    /// which is not this extension's to decide.
+    /// </summary>
+    internal static void UseSubscriptionAuth(ProcessStartInfo psi)
+    {
+        // Emptied rather than removed: the CLI reads an empty value as "no key"
+        // (its init event reports apiKeySource "none"), and leaving the name in
+        // place makes the override visible to anyone inspecting the child.
+        psi.EnvironmentVariables["ANTHROPIC_API_KEY"] = "";
     }
 
     public async IAsyncEnumerable<string> SendMessageAsync(
@@ -664,6 +678,7 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
                 CreateNoWindow = true,
                 StandardOutputEncoding = Encoding.UTF8,
             };
+            UseSubscriptionAuth(psi);
 
             using var process = new Process { StartInfo = psi };
             process.Start();
@@ -782,8 +797,15 @@ public sealed class ClaudeCliChatService : IChatService, IDisposable
                 FileName = "cmd.exe",
                 Arguments = $"/K {quotedPath} /login",
                 WorkingDirectory = _options.WorkingDirectory,
-                UseShellExecute = true,
+
+                // Started directly rather than through the shell so the key can
+                // be cleared for this console: ProcessStartInfo refuses to carry
+                // an environment when UseShellExecute is on. cmd.exe is a console
+                // program and this process is not, so Windows still gives it a
+                // window of its own — which is the point of the login flow.
+                UseShellExecute = false,
             };
+            UseSubscriptionAuth(psi);
             Process.Start(psi);
         }
         catch (Exception ex)

--- a/src/VsAgentic.Services/ClaudeCli/ClaudeCliProcessHost.cs
+++ b/src/VsAgentic.Services/ClaudeCli/ClaudeCliProcessHost.cs
@@ -137,8 +137,7 @@ public sealed class ClaudeCliProcessHost : IDisposable
             StandardErrorEncoding = Encoding.UTF8,
         };
 
-        // Strip any inherited API key so the CLI uses subscription auth.
-        psi.EnvironmentVariables["ANTHROPIC_API_KEY"] = "";
+        ClaudeCliChatService.UseSubscriptionAuth(psi);
 
         _stdinChannel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions
         {


### PR DESCRIPTION
Fixes #32

### Change

The extension keeps an inherited `ANTHROPIC_API_KEY` away from the CLI so a
session authenticates against the subscription rather than billing the key at API
rates. That intent is right. One of the two places it was done reached well past
the CLI:

```csharp
// ClaudeCliChatService constructor
Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", null);
```

No `EnvironmentVariableTarget` means `Process`, and the process is `devenv.exe`.
Opening a chat deleted the variable from Visual Studio's own environment for the
rest of the session, and therefore from everything VS started afterwards.

**Why the one-line deletion would have been wrong.** `GenerateTitleAsync` starts a
one-shot CLI process and sets no environment of its own — it was relying entirely
on the host having been scrubbed. Removing the host call alone would have let the
key reach it, turning a scoping bug into a billing one on every generated title.
`LaunchLogin` had the same gap and could not be closed the same way, because
`ProcessStartInfo` throws if `EnvironmentVariables` is touched while
`UseShellExecute` is `true`.

**What this does instead.** One `UseSubscriptionAuth(ProcessStartInfo)` helper,
called at all three sites. The long-running CLI keeps exactly the behaviour it
had, title generation gains the protection it was missing, and the login console
moves to `UseShellExecute = false` so it can be given an environment at all —
`cmd.exe` is a console program started from one that is not, so Windows still
allocates a window for it, which is the point of that flow.

The value is still set to empty rather than removed, matching what was there
before. The CLI reads an empty value as absent; its init event reports
`apiKeySource: none`.

### Trade-off worth naming

`LaunchLogin` changes how the console is started. `UseShellExecute = false` is
what makes the environment settable, and it is the only behavioural change in
this PR that a subscription user could notice. The window should appear exactly
as before — see the verification note below for how far I took that.

### Not included

No change to whether API keys are supported. README line 50 says they are not,
and this PR keeps that behaviour rather than quietly reopening the question.

Worth flagging separately, and left alone here: the answer given in #10 tells a
user to set `ANTHROPIC_API_KEY` and let the CLI pick it up. That has never worked
— the extension clears it first. Either the code or that advice should move, but
that is your call, not a drive-by change in a scoping fix.

### Verified

Builds clean. The three call sites are the complete set — a search for the
variable across `VsAgentic.Services` returns only the helper and its callers.

Not exercised at runtime. The chat and title-generation paths keep the same
effective environment they already had, so I would expect no visible difference;
the login console is the one I would want a second pair of eyes on, since
`UseShellExecute` changed and reproducing that flow means invalidating
credentials. Happy to test it against a logged-out CLI if you would rather have
that before merging.

No version bump included, same as the other PRs.
