### PR TITLE
Wrap question-card text instead of clipping it in a narrow tool window

### DIFF
--- a/src/VsAgentic.VSExtension/ToolWindows/Banners/BannerStyles.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/Banners/BannerStyles.xaml
@@ -162,15 +162,24 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="CheckBox">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Background="Transparent">
+                    <!-- Grid, not a horizontal StackPanel: a StackPanel measures
+                         its children with infinite width, so wrapping content
+                         next to the box never wraps — it just runs off the edge
+                         once the tool window gets narrow. -->
+                    <Grid Background="Transparent">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
                         <Border x:Name="box"
+                                Grid.Column="0"
                                 Width="16" Height="16"
                                 CornerRadius="4"
                                 BorderThickness="1"
                                 BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
                                 Background="Transparent"
-                                Margin="0,1,8,1"
-                                VerticalAlignment="Center"
+                                Margin="0,2,8,1"
+                                VerticalAlignment="Top"
                                 SnapsToDevicePixels="True">
                             <TextBlock x:Name="glyph"
                                        Text="✓"
@@ -183,10 +192,11 @@
                                        VerticalAlignment="Center"
                                        Visibility="Collapsed"/>
                         </Border>
-                        <ContentPresenter VerticalAlignment="Center"
-                                          HorizontalAlignment="Left"
+                        <ContentPresenter Grid.Column="1"
+                                          VerticalAlignment="Top"
+                                          HorizontalAlignment="Stretch"
                                           RecognizesAccessKey="True"/>
-                    </StackPanel>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="box" Property="BorderBrush"
@@ -217,15 +227,23 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="RadioButton">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Background="Transparent">
+                    <!-- Grid, not a horizontal StackPanel — see the CheckBox
+                         template above: an infinite measure width defeats
+                         TextWrapping on the option label / description. -->
+                    <Grid Background="Transparent">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
                         <Border x:Name="box"
+                                Grid.Column="0"
                                 Width="16" Height="16"
                                 CornerRadius="8"
                                 BorderThickness="1"
                                 BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
                                 Background="Transparent"
-                                Margin="0,1,8,1"
-                                VerticalAlignment="Center"
+                                Margin="0,2,8,1"
+                                VerticalAlignment="Top"
                                 SnapsToDevicePixels="True">
                             <Border x:Name="dot"
                                     Width="6" Height="6"
@@ -235,10 +253,11 @@
                                     VerticalAlignment="Center"
                                     Visibility="Collapsed"/>
                         </Border>
-                        <ContentPresenter VerticalAlignment="Center"
-                                          HorizontalAlignment="Left"
+                        <ContentPresenter Grid.Column="1"
+                                          VerticalAlignment="Top"
+                                          HorizontalAlignment="Stretch"
                                           RecognizesAccessKey="True"/>
-                    </StackPanel>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="box" Property="BorderBrush"

--- a/src/VsAgentic.VSExtension/ToolWindows/Banners/QuestionCardControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/Banners/QuestionCardControl.xaml
@@ -25,7 +25,8 @@
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{Binding Label}"
                                    FontWeight="SemiBold"
-                                   Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolWindowTextKey}}"/>
+                                   Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolWindowTextKey}}"
+                                   TextWrapping="Wrap"/>
                         <TextBlock Text="{Binding Description}"
                                    Visibility="{Binding HasDescription, Converter={StaticResource BoolToVis}}"
                                    Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolWindowTextKey}}"
@@ -42,7 +43,8 @@
                     <StackPanel Orientation="Vertical">
                         <TextBlock Text="{Binding Label}"
                                    FontWeight="SemiBold"
-                                   Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolWindowTextKey}}"/>
+                                   Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolWindowTextKey}}"
+                                   TextWrapping="Wrap"/>
                         <TextBlock Text="{Binding Description}"
                                    Visibility="{Binding HasDescription, Converter={StaticResource BoolToVis}}"
                                    Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolWindowTextKey}}"
@@ -136,7 +138,11 @@
                                  Style="{StaticResource BannerInputTextBoxStyle}"
                                  Text="{Binding OtherText, UpdateSourceTrigger=PropertyChanged}"
                                  ToolTip="Type your own answer"
-                                 MinWidth="200"/>
+                                 TextWrapping="Wrap"
+                                 AcceptsReturn="False"
+                                 MaxHeight="90"
+                                 VerticalScrollBarVisibility="Auto"
+                                 MinWidth="80"/>
                     </Grid>
                 </StackPanel>
             </DataTemplate>


### PR DESCRIPTION
Fixes #11.

The themed `RadioButton`/`CheckBox` `ControlTemplate`s in `BannerStyles.xaml` laid their toggle box and their content out in a horizontal `StackPanel`, which measures children with infinite width. `TextWrapping` on the option label and description therefore never engaged: the text was laid out on a single line and clipped by the card edge, so the only way to read a long option was to widen the tool window.

Both templates now use a two-column `Grid` — `Auto` for the box, `*` for the content — so the content is measured against the real available width. The box is top-aligned so it stays on the first line of a wrapped option instead of centering against the whole block.

Alongside that, in `QuestionCardControl.xaml`: the option label gets `TextWrapping="Wrap"` (previously only the description had it), and the "Other:" free-text box wraps its input, caps at 90px with a scrollbar, and drops its `MinWidth` from 200 to 80 so it still fits beside the toggle in a narrow pane.

Details and root-cause analysis: https://github.com/adospace/vs-agentic/issues/11#issuecomment-5413558772

Verified by deploying to the experimental instance and docking the chat pane narrow; also measured headlessly — same option content at 300px available width goes from 30.6px tall (two unwrapped lines running off the edge) to 59.9px within 281.6px (four wrapped lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
