### PR TITLE
Add browser-style zoom to the chat window

### DIFF
--- a/src/VsAgentic.UI/Assets/chat-template.html
+++ b/src/VsAgentic.UI/Assets/chat-template.html
@@ -751,6 +751,34 @@ document.addEventListener('click', function(e) {
     }
 });
 
+// --- Zoom ---
+// The host owns the zoom level, because it also scales the input box and the
+// banners that sit outside this page. Ctrl+wheel and Ctrl+/- are swallowed by
+// the browser whenever the pointer or focus is in here, so forward the intent
+// rather than acting on it: +1 in, -1 out, 0 back to 100%.
+function requestZoom(step) {
+    window.chrome.webview.postMessage(JSON.stringify({type:'zoom', step:step}));
+}
+
+// passive:false — preventDefault is ignored on a passive wheel listener, and
+// the chat would scroll while zooming.
+window.addEventListener('wheel', function(e) {
+    if (!e.ctrlKey || e.deltaY === 0) return;
+    e.preventDefault();
+    requestZoom(e.deltaY < 0 ? 1 : -1);
+}, {passive: false});
+
+window.addEventListener('keydown', function(e) {
+    if (!e.ctrlKey || e.altKey) return;
+    // e.code catches the numpad and layouts where '+' needs a shift; e.key
+    // catches the rest. '=' is the unshifted US '+' key, which browsers accept.
+    if (e.key === '+' || e.key === '=' || e.code === 'NumpadAdd') requestZoom(1);
+    else if (e.key === '-' || e.code === 'NumpadSubtract') requestZoom(-1);
+    else if (e.key === '0' || e.code === 'Numpad0') requestZoom(0);
+    else return;
+    e.preventDefault();
+});
+
 // --- Copy button ---
 // SVG icons for copy button
 var ICON_COPY = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M3.5 10.5h-1a1.5 1.5 0 01-1.5-1.5v-6a1.5 1.5 0 011.5-1.5h6a1.5 1.5 0 011.5 1.5v1"/></svg>';

--- a/src/VsAgentic.UI/Controls/ChatWebView.xaml.cs
+++ b/src/VsAgentic.UI/Controls/ChatWebView.xaml.cs
@@ -19,8 +19,32 @@ public partial class ChatWebView : UserControl
     /// </summary>
     public static event Action<string>? FileOpenRequested;
 
+    /// <summary>
+    /// Raised when the page asks for a zoom change: +1 in, -1 out, 0 back to
+    /// 100%. Ctrl+wheel and Ctrl+/- land inside the browser whenever the
+    /// pointer or focus is over the chat and never reach WPF, so the page
+    /// forwards the intent here instead of zooming itself — the host owns the
+    /// single level that the chat and the chrome around it share.
+    /// </summary>
+    public event Action<int>? ZoomChangeRequested;
+
     private bool _isWebViewReady;
+    private double _zoomFactor = ZoomLevels.Default;
     private readonly ConcurrentQueue<Func<Task>> _pendingOps = new();
+
+    /// <summary>
+    /// Scale applied to the rendered chat. Safe to set before the WebView has
+    /// finished initializing; the value is re-applied once it has.
+    /// </summary>
+    public double ZoomFactor
+    {
+        get => _zoomFactor;
+        set
+        {
+            _zoomFactor = value;
+            ApplyZoomFactor();
+        }
+    }
 
     public ChatWebView()
     {
@@ -78,9 +102,27 @@ public partial class ChatWebView : UserControl
         return reader.ReadToEnd();
     }
 
+    /// <summary>
+    /// Pushes the current level at the control. Before CoreWebView2 exists this
+    /// is a no-op rather than an error, which is why the level is kept in a
+    /// field and re-applied when navigation completes.
+    /// </summary>
+    private void ApplyZoomFactor()
+    {
+        try
+        {
+            WebView.ZoomFactor = _zoomFactor;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"ChatWebView zoom failed: {ex.Message}");
+        }
+    }
+
     private async void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
     {
         _isWebViewReady = true;
+        ApplyZoomFactor();
 
         // Replay queued operations
         while (_pendingOps.TryDequeue(out var op))
@@ -109,6 +151,10 @@ public partial class ChatWebView : UserControl
                 var path = root.GetProperty("path").GetString();
                 if (!string.IsNullOrEmpty(path))
                     FileOpenRequested?.Invoke(path!);
+            }
+            else if (type == "zoom")
+            {
+                ZoomChangeRequested?.Invoke(root.GetProperty("step").GetInt32());
             }
         }
         catch

--- a/src/VsAgentic.UI/Controls/ZoomLevels.cs
+++ b/src/VsAgentic.UI/Controls/ZoomLevels.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+
+namespace VsAgentic.UI.Controls;
+
+/// <summary>
+/// The ladder of zoom steps the chat moves through, and the arithmetic for
+/// stepping along it. Modelled on a browser's ladder rather than a fixed
+/// increment: coarse at the ends, where a few percent make no visible
+/// difference, and fine around 100%, which is where most users sit.
+/// </summary>
+public static class ZoomLevels
+{
+    /// <summary>The level a fresh install starts at, and what Ctrl+0 returns to.</summary>
+    public const double Default = 1.0;
+
+    private static readonly double[] Steps =
+    {
+        0.5, 0.67, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0
+    };
+
+    /// <summary>
+    /// Snaps an arbitrary value to the nearest step. Anything arriving from
+    /// outside — a restored setting, a hand-edited registry value — goes
+    /// through here, so the rest of the code only ever sees a real step and
+    /// <see cref="Step"/> can compare for exact equality.
+    /// </summary>
+    public static double Normalize(double level)
+    {
+        var nearest = Steps[0];
+        foreach (var step in Steps)
+        {
+            if (Math.Abs(step - level) < Math.Abs(nearest - level))
+                nearest = step;
+        }
+        return nearest;
+    }
+
+    /// <summary>
+    /// The step one place <paramref name="direction"/> from
+    /// <paramref name="level"/> (+1 zooms in, -1 out), clamped at both ends so
+    /// holding the wheel down never runs off the ladder.
+    /// </summary>
+    public static double Step(double level, int direction)
+    {
+        var index = Array.IndexOf(Steps, Normalize(level));
+        var next = Math.Max(0, Math.Min(Steps.Length - 1, index + Math.Sign(direction)));
+        return Steps[next];
+    }
+
+    /// <summary>The level as a caption, e.g. "110%".</summary>
+    public static string Format(double level) =>
+        ((int)Math.Round(level * 100)).ToString(CultureInfo.InvariantCulture) + "%";
+}

--- a/src/VsAgentic.VSExtension/Options/VsAgenticOptionsPage.cs
+++ b/src/VsAgentic.VSExtension/Options/VsAgenticOptionsPage.cs
@@ -25,6 +25,12 @@ public class VsAgenticOptionsPage : DialogPage
     [DefaultValue(CliPermissionMode.Default)]
     public CliPermissionMode CliPermissionMode { get; set; } = CliPermissionMode.Default;
 
+    [Category("Appearance")]
+    [DisplayName("Zoom (%)")]
+    [Description("Size of the chat text and the controls around it, as a percentage. Normally set with Ctrl+mouse wheel or Ctrl+Plus/Minus in the chat window (Ctrl+0 restores 100%); this is where that choice is remembered between restarts. Values are snapped to the nearest zoom step, between 50 and 300.")]
+    [DefaultValue(100)]
+    public int ZoomPercent { get; set; } = 100;
+
     [Category("Sessions")]
     [DisplayName("Keep days of activity")]
     [Description("When the extension starts, sessions whose last activity is older than this many days are deleted. Default: 30. Set to 0 to disable cleanup.")]

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
@@ -119,7 +119,6 @@
         </Style>
     </UserControl.Resources>
 
-    <Grid>
     <DockPanel x:Name="RootPanel"
                Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}">
 
@@ -331,30 +330,41 @@
         </ContentControl>
 
         <!-- Chat Messages Area - single WebView -->
-        <controls:ChatWebView x:Name="ChatWebView" />
-    </DockPanel>
+        <Grid>
+            <controls:ChatWebView x:Name="ChatWebView" />
 
-    <!-- Zoom reading, shown for a moment after each step and then faded out,
-         the way a browser does it. Deliberately outside the scaled chrome and
-         at a fixed size: it reports the zoom, so it must not be subject to it.
-         Not hit-testable, so it never swallows a click on whatever it happens
-         to be covering. -->
-    <Border x:Name="ZoomToast"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Top"
-            Margin="0,8,12,0"
-            Padding="10,4"
-            CornerRadius="3"
-            Opacity="0"
-            Visibility="Collapsed"
-            IsHitTestVisible="False"
-            Background="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBackgroundKey}}"
-            BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
-            BorderThickness="1">
-        <TextBlock x:Name="ZoomToastText"
-                   FontSize="12"
-                   FontWeight="SemiBold"
-                   Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
-    </Border>
-    </Grid>
+            <!-- Zoom reading, shown in the corner of the chat for a moment
+                 after each step and then faded out, the way a browser does it.
+
+                 A Popup rather than a plain Border in this Grid, because the
+                 WebView2 control is an HwndHost: WPF cannot draw over a child
+                 HWND, so a Border laid on top would simply not appear where it
+                 overlapped the chat. A Popup gets its own top-level window and
+                 sits above it.
+
+                 Deliberately outside the scaled chrome and at a fixed size — it
+                 reports the zoom, so it must not be subject to it. -->
+            <Popup x:Name="ZoomToast"
+                   PlacementTarget="{Binding ElementName=ChatWebView}"
+                   Placement="Custom"
+                   StaysOpen="True"
+                   AllowsTransparency="True"
+                   PopupAnimation="Fade"
+                   Focusable="False"
+                   IsHitTestVisible="False">
+                <Border Padding="10,4"
+                        CornerRadius="3"
+                        IsHitTestVisible="False"
+                        Background="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBackgroundKey}}"
+                        BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
+                        BorderThickness="1"
+                        SnapsToDevicePixels="True">
+                    <TextBlock x:Name="ZoomToastText"
+                               FontSize="12"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
+                </Border>
+            </Popup>
+        </Grid>
+    </DockPanel>
 </UserControl>

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml
@@ -6,10 +6,21 @@
              xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              xmlns:controls="clr-namespace:VsAgentic.UI.Controls;assembly=VsAgentic.UI"
              xmlns:bvm="clr-namespace:VsAgentic.UI.ViewModels.Banners;assembly=VsAgentic.UI"
-             xmlns:bv="clr-namespace:VsAgentic.VSExtension.ToolWindows.Banners" >
+             xmlns:bv="clr-namespace:VsAgentic.VSExtension.ToolWindows.Banners"
+             PreviewMouseWheel="OnPreviewMouseWheel"
+             PreviewKeyDown="OnPreviewKeyDown" >
 
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+
+        <!-- Zoom for everything that is not the WebView. One instance, shared
+             by LayoutTransform on each docked child, so the code-behind moves
+             the whole chrome by setting a single pair of numbers. LayoutTransform
+             rather than RenderTransform: the scaled chrome has to claim its new
+             size from the DockPanel, otherwise it grows over the chat instead
+             of pushing it. The chat itself is scaled through the browser's own
+             zoom, which stays crisp where a bitmap scale would not. -->
+        <ScaleTransform x:Key="ChromeZoom" ScaleX="1" ScaleY="1"/>
 
         <!-- Banner DataTemplates: ContentControl below picks the right view by VM type. -->
         <DataTemplate DataType="{x:Type bvm:PermissionBannerViewModel}">
@@ -108,11 +119,13 @@
         </Style>
     </UserControl.Resources>
 
+    <Grid>
     <DockPanel x:Name="RootPanel"
                Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}">
 
         <!-- Input Area -->
         <Border DockPanel.Dock="Bottom"
+                LayoutTransform="{StaticResource ChromeZoom}"
                 Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}"
                 Padding="6,2,6,6">
             <Grid>
@@ -288,6 +301,7 @@
 
         <!-- Busy indicator -->
         <Border DockPanel.Dock="Bottom"
+                LayoutTransform="{StaticResource ChromeZoom}"
                 Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}"
                 Padding="16,4"
                 Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
@@ -301,6 +315,7 @@
              when ActiveBanner is null so it consumes no space when idle. -->
         <ContentControl DockPanel.Dock="Bottom"
                         x:Name="BannerHost"
+                        LayoutTransform="{StaticResource ChromeZoom}"
                         Content="{Binding ActiveBanner}"
                         Focusable="False">
             <ContentControl.Style>
@@ -318,4 +333,28 @@
         <!-- Chat Messages Area - single WebView -->
         <controls:ChatWebView x:Name="ChatWebView" />
     </DockPanel>
+
+    <!-- Zoom reading, shown for a moment after each step and then faded out,
+         the way a browser does it. Deliberately outside the scaled chrome and
+         at a fixed size: it reports the zoom, so it must not be subject to it.
+         Not hit-testable, so it never swallows a click on whatever it happens
+         to be covering. -->
+    <Border x:Name="ZoomToast"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Top"
+            Margin="0,8,12,0"
+            Padding="10,4"
+            CornerRadius="3"
+            Opacity="0"
+            Visibility="Collapsed"
+            IsHitTestVisible="False"
+            Background="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBackgroundKey}}"
+            BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
+            BorderThickness="1">
+        <TextBlock x:Name="ZoomToastText"
+                   FontSize="12"
+                   FontWeight="SemiBold"
+                   Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"/>
+    </Border>
+    </Grid>
 </UserControl>

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
@@ -1,9 +1,9 @@
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
@@ -87,6 +87,10 @@ public partial class ChatSessionControl : UserControl
         VSColorTheme.ThemeChanged -= OnThemeChanged;
         ChatZoom.Changed -= OnZoomChanged;
         ChatWebView.ZoomChangeRequested -= OnZoomChangeRequested;
+
+        // A popup is its own window and would outlive the pane it belongs to.
+        _zoomToastTimer?.Stop();
+        ZoomToast.IsOpen = false;
     }
 
     private void OnThemeChanged(ThemeChangedEventArgs e)
@@ -133,7 +137,6 @@ public partial class ChatSessionControl : UserControl
     // ------------------------------------------------------------------
 
     private static readonly TimeSpan ZoomToastHold = TimeSpan.FromMilliseconds(900);
-    private static readonly Duration ZoomToastFade = new Duration(TimeSpan.FromMilliseconds(250));
 
     private DispatcherTimer? _zoomToastTimer;
 
@@ -172,7 +175,12 @@ public partial class ChatSessionControl : UserControl
     private void OnZoomChanged(double level)
     {
         ApplyZoom(level);
-        ShowZoomToast(level);
+
+        // Every open chat window follows the level, but only the one being
+        // looked at flashes the reading. A popup belongs to no pane in
+        // particular once it is open, so a background tab would put its pill
+        // on top of whatever the user is actually working in.
+        if (IsVisible) ShowZoomToast(level);
     }
 
     /// <summary>
@@ -199,18 +207,31 @@ public partial class ChatSessionControl : UserControl
     private void ShowZoomToast(double level)
     {
         ZoomToastText.Text = ZoomLevels.Format(level);
+        ZoomToast.CustomPopupPlacementCallback ??= PlaceZoomToast;
 
-        // Clear any fade still running from the previous step first — a local
-        // value loses to a live animation, so without this a quick run of
-        // notches leaves the reading stuck half-transparent.
-        ZoomToast.BeginAnimation(OpacityProperty, null);
-        ZoomToast.Opacity = 1;
-        ZoomToast.Visibility = Visibility.Visible;
+        // Reopening an already-open popup does not re-run placement, and the
+        // reading changes width between "90%" and "100%"; closing first keeps
+        // it pinned to the corner instead of drifting left as it grows.
+        ZoomToast.IsOpen = false;
+        ZoomToast.IsOpen = true;
 
         _zoomToastTimer ??= CreateZoomToastTimer();
         _zoomToastTimer.Stop();
         _zoomToastTimer.Start();
     }
+
+    /// <summary>
+    /// Pins the reading to the chat's top-right corner. A callback rather than
+    /// a fixed offset because only here are both sizes known, and the popup's
+    /// width moves with the number in it.
+    /// </summary>
+    private static CustomPopupPlacement[] PlaceZoomToast(Size popupSize, Size targetSize, Point offset) =>
+        new[]
+        {
+            new CustomPopupPlacement(
+                new Point(targetSize.Width - popupSize.Width - 12, 8),
+                PopupPrimaryAxis.None)
+        };
 
     private DispatcherTimer CreateZoomToastTimer()
     {
@@ -218,15 +239,9 @@ public partial class ChatSessionControl : UserControl
         timer.Tick += (_, _) =>
         {
             timer.Stop();
-
-            var fade = new DoubleAnimation(0, ZoomToastFade);
-            // A step landing in the same instant re-shows the toast; only
-            // collapse if this fade is still the one that finished.
-            fade.Completed += (_, _) =>
-            {
-                if (ZoomToast.Opacity == 0) ZoomToast.Visibility = Visibility.Collapsed;
-            };
-            ZoomToast.BeginAnimation(OpacityProperty, fade);
+            // PopupAnimation="Fade" carries the close, so there is no animation
+            // to run or unwind here.
+            ZoomToast.IsOpen = false;
         };
         return timer;
     }

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionControl.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Threading;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using VsAgentic.UI.Controls;
@@ -63,6 +65,28 @@ public partial class ChatSessionControl : UserControl
 
         // Re-apply when VS theme changes
         VSColorTheme.ThemeChanged += OnThemeChanged;
+
+        // Ctrl+wheel and Ctrl+/- over the chat itself are seen by the browser,
+        // not by WPF; the page relays them.
+        ChatWebView.ZoomChangeRequested += OnZoomChangeRequested;
+
+        // Zoom is one setting across every chat window, so follow it rather
+        // than own it. Applied without the toast here: this is the window
+        // adopting the level it was born into, not the user changing it.
+        ChatZoom.Changed += OnZoomChanged;
+        ApplyZoom(ChatZoom.Level);
+    }
+
+    /// <summary>
+    /// Drops the static-event subscriptions this control took out in
+    /// <see cref="Initialize"/>. Called when the tool window closes — not on
+    /// Unloaded, which VS also raises when the window is merely tabbed away.
+    /// </summary>
+    public void Shutdown()
+    {
+        VSColorTheme.ThemeChanged -= OnThemeChanged;
+        ChatZoom.Changed -= OnZoomChanged;
+        ChatWebView.ZoomChangeRequested -= OnZoomChangeRequested;
     }
 
     private void OnThemeChanged(ThemeChangedEventArgs e)
@@ -104,6 +128,109 @@ public partial class ChatSessionControl : UserControl
         _ = ChatWebView.SetThemeColorsAsync(colors);
     }
 
+    // ------------------------------------------------------------------
+    // Zoom
+    // ------------------------------------------------------------------
+
+    private static readonly TimeSpan ZoomToastHold = TimeSpan.FromMilliseconds(900);
+    private static readonly Duration ZoomToastFade = new Duration(TimeSpan.FromMilliseconds(250));
+
+    private DispatcherTimer? _zoomToastTimer;
+
+    private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if ((Keyboard.Modifiers & ModifierKeys.Control) != ModifierKeys.Control || e.Delta == 0)
+            return;
+
+        ChatZoom.Step(e.Delta > 0 ? 1 : -1);
+        e.Handled = true;
+    }
+
+    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if ((Keyboard.Modifiers & ModifierKeys.Control) != ModifierKeys.Control) return;
+
+        // Numpad and main-row alike, as a browser does. Marking the key handled
+        // matters beyond WPF: Ctrl+Minus is Navigate Backward in Visual Studio,
+        // and anything left unhandled here goes on to the shell's commands.
+        int? step = e.Key switch
+        {
+            Key.Add or Key.OemPlus => 1,
+            Key.Subtract or Key.OemMinus => -1,
+            Key.NumPad0 or Key.D0 => 0,
+            _ => null,
+        };
+
+        if (step is null) return;
+
+        ChatZoom.Step(step.Value);
+        e.Handled = true;
+    }
+
+    private void OnZoomChangeRequested(int step) => ChatZoom.Step(step);
+
+    private void OnZoomChanged(double level)
+    {
+        ApplyZoom(level);
+        ShowZoomToast(level);
+    }
+
+    /// <summary>
+    /// The factor the chrome is currently scaled by. Read off the transform
+    /// rather than <see cref="ChatZoom.Level"/> so anything measuring against
+    /// it stays right even mid-change.
+    /// </summary>
+    private double ZoomScale =>
+        Resources["ChromeZoom"] is ScaleTransform chrome && chrome.ScaleY > 0
+            ? chrome.ScaleY
+            : 1.0;
+
+    private void ApplyZoom(double level)
+    {
+        ChatWebView.ZoomFactor = level;
+
+        if (Resources["ChromeZoom"] is ScaleTransform chrome)
+        {
+            chrome.ScaleX = level;
+            chrome.ScaleY = level;
+        }
+    }
+
+    private void ShowZoomToast(double level)
+    {
+        ZoomToastText.Text = ZoomLevels.Format(level);
+
+        // Clear any fade still running from the previous step first — a local
+        // value loses to a live animation, so without this a quick run of
+        // notches leaves the reading stuck half-transparent.
+        ZoomToast.BeginAnimation(OpacityProperty, null);
+        ZoomToast.Opacity = 1;
+        ZoomToast.Visibility = Visibility.Visible;
+
+        _zoomToastTimer ??= CreateZoomToastTimer();
+        _zoomToastTimer.Stop();
+        _zoomToastTimer.Start();
+    }
+
+    private DispatcherTimer CreateZoomToastTimer()
+    {
+        var timer = new DispatcherTimer(DispatcherPriority.Normal, Dispatcher) { Interval = ZoomToastHold };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+
+            var fade = new DoubleAnimation(0, ZoomToastFade);
+            // A step landing in the same instant re-shows the toast; only
+            // collapse if this fade is still the one that finished.
+            fade.Completed += (_, _) =>
+            {
+                if (ZoomToast.Opacity == 0) ZoomToast.Visibility = Visibility.Collapsed;
+            };
+            ZoomToast.BeginAnimation(OpacityProperty, fade);
+        };
+        return timer;
+    }
+
     private void InputTextBox_KeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key == Key.Enter &&
@@ -140,10 +267,14 @@ public partial class ChatSessionControl : UserControl
 
         var currentScreenY = PointToScreen(e.GetPosition(this)).Y;
         // Dragging upward decreases Y, which should grow the input box.
-        var delta = _resizeStartScreenY - currentScreenY;
+        // The drag is measured outside the zoom transform and the height is set
+        // inside it, so divide: at 200% the box would otherwise grow twice as
+        // fast as the pointer, and the same factor applies to the cap.
+        var zoom = ZoomScale;
+        var delta = (_resizeStartScreenY - currentScreenY) / zoom;
         var requested = _resizeStartHeight + delta;
 
-        var maxHeight = Math.Max(InputMinHeight, RootPanel.ActualHeight / 2);
+        var maxHeight = Math.Max(InputMinHeight, RootPanel.ActualHeight / (2 * zoom));
         var newHeight = Math.Max(InputMinHeight, Math.Min(requested, maxHeight));
 
         // Pin the textbox to the dragged height so it neither grows with

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatSessionToolWindow.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatSessionToolWindow.cs
@@ -23,6 +23,7 @@ public class ChatSessionToolWindow : ToolWindowPane
 
     protected override void OnClose()
     {
+        ChatControl.Shutdown();
         Closed?.Invoke();
         base.OnClose();
     }

--- a/src/VsAgentic.VSExtension/ToolWindows/ChatZoom.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/ChatZoom.cs
@@ -1,0 +1,46 @@
+using VsAgentic.UI.Controls;
+
+namespace VsAgentic.VSExtension.ToolWindows;
+
+/// <summary>
+/// The one zoom level every chat window renders at.
+///
+/// Deliberately shared rather than per-window: this is an accessibility
+/// setting, not a per-tab view state. Someone who turns it up because the text
+/// is too small means it for every window, including ones opened later, the
+/// same way the editor's font size applies everywhere.
+///
+/// The level lives here rather than on the options page so a window can react
+/// without reaching for the package; <see cref="VsAgenticPackage"/> seeds it at
+/// startup and writes changes back to the registry.
+/// </summary>
+internal static class ChatZoom
+{
+    private static double _level = ZoomLevels.Default;
+
+    /// <summary>Raised on the UI thread whenever <see cref="Level"/> changes.</summary>
+    public static event Action<double>? Changed;
+
+    /// <summary>The current level, always one of the <see cref="ZoomLevels"/> steps.</summary>
+    public static double Level => _level;
+
+    /// <summary>
+    /// Seeds the level from the persisted setting. Silent by design — it runs
+    /// before any window exists, so there is nothing to notify and nothing to
+    /// write back.
+    /// </summary>
+    public static void Initialize(double level) => _level = ZoomLevels.Normalize(level);
+
+    /// <summary>
+    /// Moves one step in (+1), one step out (-1), or back to 100% (0).
+    /// </summary>
+    public static void Step(int direction)
+    {
+        _level = direction == 0 ? ZoomLevels.Default : ZoomLevels.Step(_level, direction);
+
+        // Notified even when the step was a no-op at either end of the ladder,
+        // so the reading still flashes up. A browser does the same, and the
+        // alternative — silence — reads as a dead keyboard shortcut.
+        Changed?.Invoke(_level);
+    }
+}

--- a/src/VsAgentic.VSExtension/VsAgenticPackage.cs
+++ b/src/VsAgentic.VSExtension/VsAgenticPackage.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows;
+using System.Windows.Threading;
 using VsAgentic.Services.Abstractions;
 using VsAgentic.Services.DependencyInjection;
 using VsAgentic.Services.Services;
@@ -43,6 +44,8 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
     private static readonly SemaphoreSlim _openSessionGate = new(1, 1);
     private int _nextWindowId;
     private uint _solutionEventsCookie;
+    private Action<double>? _persistZoom;
+    private DispatcherTimer? _zoomSaveTimer;
 
     public static bool IsLoaded => _instance is not null;
 
@@ -86,6 +89,8 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
         // Listen for file-open requests from rendered markdown
         ChatWebView.FileOpenRequested += OnFileOpenRequested;
 
+        InitializeZoom();
+
         // Listen for solution open/close/switch events
         if (await GetServiceAsync(typeof(SVsSolution)) is IVsSolution solutionService)
         {
@@ -106,6 +111,54 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
             }
             catch (OperationCanceledException) { }
         }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Seeds the shared chat zoom from the persisted setting and writes every
+    /// later change straight back. Zoom is set from the chat window rather than
+    /// from Tools → Options, so nothing else would ever save it.
+    /// </summary>
+    private void InitializeZoom()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        var optionsPage = (VsAgenticOptionsPage?)GetDialogPage(typeof(VsAgenticOptionsPage));
+        if (optionsPage is null) return;
+
+        ChatZoom.Initialize(optionsPage.ZoomPercent / 100.0);
+
+        // Coalesced rather than written per step: SaveSettingsToStorage
+        // reflects over the whole page and hits the settings store, and one
+        // spin of the wheel is a dozen steps. Writing inline would stutter the
+        // very gesture this feature exists for.
+        _zoomSaveTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(500)
+        };
+        _zoomSaveTimer.Tick += (_, _) => SaveZoomSetting(optionsPage);
+
+        _persistZoom = _ =>
+        {
+            _zoomSaveTimer.Stop();
+            _zoomSaveTimer.Start();
+        };
+        ChatZoom.Changed += _persistZoom;
+    }
+
+    private void SaveZoomSetting(VsAgenticOptionsPage optionsPage)
+    {
+        _zoomSaveTimer?.Stop();
+
+        try
+        {
+            optionsPage.ZoomPercent = (int)Math.Round(ChatZoom.Level * 100);
+            optionsPage.SaveSettingsToStorage();
+        }
+        catch (Exception ex)
+        {
+            // Worst case the level is forgotten at the next restart.
+            System.Diagnostics.Debug.WriteLine($"VsAgentic: Failed to persist zoom: {ex}");
+        }
     }
 
     private async Task InitializeSessionPersistenceAsync()
@@ -539,6 +592,21 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
         if (disposing)
         {
             ChatWebView.FileOpenRequested -= OnFileOpenRequested;
+
+            if (_persistZoom is not null)
+            {
+                ChatZoom.Changed -= _persistZoom;
+                _persistZoom = null;
+            }
+
+            // A zoom step in the last half-second still has its write pending;
+            // flush it rather than lose it on the way out.
+            if (_zoomSaveTimer is { IsEnabled: true }
+                && GetDialogPage(typeof(VsAgenticOptionsPage)) is VsAgenticOptionsPage optionsPage)
+            {
+                SaveZoomSetting(optionsPage);
+            }
+            _zoomSaveTimer?.Stop();
 
             if (_solutionEventsCookie != 0)
             {


### PR DESCRIPTION
Fixes #29.

The request was a way to make the text bigger. Rather than a font-size setting buried in Tools -> Options, this is the gesture people already know from a browser: **Ctrl+mouse wheel**, **Ctrl+Plus/Minus** (numpad or main row), and **Ctrl+0** back to 100%, with the reading flashed up in the corner of the chat as it changes. Steps follow a browser's ladder, 50% to 300%.

The level is one setting shared by every open chat window, persisted to **Tools -> Options -> VsAgentic -> Zoom (%)** so it survives a restart. Writes to the settings store are coalesced over 500ms, because `SaveSettingsToStorage` reflects over the whole options page and one spin of the wheel is a dozen steps.

### How it works

The window is half browser and half WPF, so there are two mechanisms under one level:

- **The chat** is scaled through WebView2's own zoom, which re-lays-out the page and stays crisp. Ctrl+wheel and Ctrl+/- never reach WPF while the pointer or focus is over the chat, so the page forwards the intent to the host instead of zooming itself.
- **The chrome** (header, input box, banners, busy line) is scaled with a shared `LayoutTransform`, so it claims its new size from the `DockPanel` rather than growing over the chat. Without this the person who needed larger text would still be typing into a 13px box.

### Notes for review

- The zoom reading is a `Popup`, not a `Border` in the visual tree. `WebView2` is an `HwndHost` and WPF cannot draw over a child HWND, so an overlay would simply not appear where it covered the chat. Only the visible window shows it — a popup belongs to no pane once open, so a background tab would otherwise drop its pill on top of whatever the user is working in.
- The input resize grip is measured outside the transform and applied inside it, so its drag delta and its half-the-window cap are both divided by the level; otherwise the box grew at twice pointer speed at 200%.
- `Ctrl+Minus` is Navigate Backward in Visual Studio, so the key handler marks the event handled to keep it out of the shell's command routing.

Tested manually in the experimental instance: both wheel paths (over the chat and over the input), the numpad and main-row keys, Ctrl+0, the reading, chrome scaling, two windows sharing the level, and persistence across a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)