### PR TITLE
Let the user rename a session and pin it to the top of the list

### DIFF
--- a/src/VsAgentic.Services/Models/SessionEntry.cs
+++ b/src/VsAgentic.Services/Models/SessionEntry.cs
@@ -4,6 +4,14 @@ public class SessionEntry
 {
     public int Id { get; set; }
     public string Title { get; set; } = "New Session";
+
+    /// <summary>
+    /// True once the user has renamed the session by hand. The title generated
+    /// from the first message is then skipped, so a manual name is never
+    /// overwritten.
+    /// </summary>
+    public bool TitleIsCustom { get; set; }
+
     public int Ordinal { get; set; }
     public DateTime CreatedUtc { get; set; }
     public DateTime LastActivityUtc { get; set; }

--- a/src/VsAgentic.Services/Models/SessionEntry.cs
+++ b/src/VsAgentic.Services/Models/SessionEntry.cs
@@ -12,6 +12,11 @@ public class SessionEntry
     /// </summary>
     public bool TitleIsCustom { get; set; }
 
+    /// <summary>
+    /// Pinned sessions are listed above the rest, regardless of activity.
+    /// </summary>
+    public bool IsPinned { get; set; }
+
     public int Ordinal { get; set; }
     public DateTime CreatedUtc { get; set; }
     public DateTime LastActivityUtc { get; set; }

--- a/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/ChatSessionViewModel.cs
@@ -38,6 +38,13 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string _sessionTitle = "New Session";
 
+    /// <summary>
+    /// True when <see cref="SessionTitle"/> was typed by the user in the
+    /// session list. The title generated from the first message is then
+    /// skipped so the manual name survives.
+    /// </summary>
+    public bool HasCustomTitle { get; set; }
+
     // Realtime activity indicator: a braille spinner prefix while the AI is
     // working, a steady "? " prefix while awaiting user input (permission /
     // question banner), and no prefix while idle. Host bindings (e.g. the VS
@@ -392,9 +399,10 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
             return;
         }
 
-        // Generate a title from the first user message (fire-and-forget, non-blocking)
+        // Generate a title from the first user message (fire-and-forget, non-blocking).
+        // Skipped when the user already named the session by hand.
         var isFirstMessage = Items.Count(i => i.Type == ChatItemType.User) == 1;
-        if (isFirstMessage)
+        if (isFirstMessage && !HasCustomTitle)
         {
             _ = Task.Run(async () =>
             {
@@ -403,6 +411,10 @@ public partial class ChatSessionViewModel : ObservableObject, IDisposable
                     var title = await _chatService.GenerateTitleAsync(message);
                     Dispatch(() =>
                     {
+                        // The user may have renamed the session while the
+                        // title was being generated.
+                        if (HasCustomTitle) return;
+
                         SessionTitle = title;
                         PersistTitleUpdateFireAndForget(title);
                     });

--- a/src/VsAgentic.UI/ViewModels/SessionListViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/SessionListViewModel.cs
@@ -60,6 +60,12 @@ public partial class SessionInfo : ObservableObject
     private bool _isActive;
 
     /// <summary>
+    /// Pinned sessions stay at the top of the list.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isPinned;
+
+    /// <summary>
     /// True while the row shows its inline rename box. Only one session at a
     /// time is in this state.
     /// </summary>
@@ -145,13 +151,16 @@ public partial class SessionListViewModel : ObservableObject
         var entries = await _sessionStore.GetSessionIndexAsync(_folderPath);
         Sessions.Clear();
 
-        foreach (var entry in entries.OrderByDescending(e => e.LastActivityUtc))
+        foreach (var entry in entries
+                     .OrderByDescending(e => e.IsPinned)
+                     .ThenByDescending(e => e.LastActivityUtc))
         {
             var info = new SessionInfo
             {
                 PersistedId = entry.Id,
                 Name = entry.Title,
                 HasCustomTitle = entry.TitleIsCustom,
+                IsPinned = entry.IsPinned,
                 LastActivity = entry.LastActivityUtc.ToLocalTime(),
                 IsActive = false
             };
@@ -179,9 +188,54 @@ public partial class SessionListViewModel : ObservableObject
             catch { /* best effort — session works in-memory even if persistence fails */ }
         }
 
-        Sessions.Insert(0, session);
+        // Newest first, but below whatever the user pinned.
+        Sessions.Insert(Sessions.TakeWhile(s => s.IsPinned).Count(), session);
         SelectedSession = session;
         SessionOpenRequested?.Invoke(session);
+    }
+
+    /// <summary>
+    /// Pins or unpins a session and moves it to its place in the list.
+    /// </summary>
+    [RelayCommand]
+    private async Task TogglePinAsync(SessionInfo? session)
+    {
+        if (session is null) return;
+
+        session.IsPinned = !session.IsPinned;
+        ApplyPinnedOrder();
+
+        if (session.PersistedId.HasValue && _sessionStore is not null && _folderPath is not null)
+        {
+            try
+            {
+                var index = await _sessionStore.GetSessionIndexAsync(_folderPath);
+                var entry = index.FirstOrDefault(e => e.Id == session.PersistedId.Value);
+                if (entry is not null)
+                {
+                    entry.IsPinned = session.IsPinned;
+                    await _sessionStore.UpdateSessionAsync(_folderPath, entry);
+                }
+            }
+            catch { /* best effort — the order still holds for this session */ }
+        }
+    }
+
+    /// <summary>
+    /// Moves pinned sessions to the top. OrderBy is stable, so the relative
+    /// order inside each group survives — pinning and unpinning only ever
+    /// moves the one row across the boundary.
+    /// </summary>
+    private void ApplyPinnedOrder()
+    {
+        var ordered = Sessions.OrderByDescending(s => s.IsPinned).ToList();
+
+        for (var target = 0; target < ordered.Count; target++)
+        {
+            var current = Sessions.IndexOf(ordered[target]);
+            if (current != target)
+                Sessions.Move(current, target);
+        }
     }
 
     [RelayCommand]

--- a/src/VsAgentic.UI/ViewModels/SessionListViewModel.cs
+++ b/src/VsAgentic.UI/ViewModels/SessionListViewModel.cs
@@ -60,6 +60,26 @@ public partial class SessionInfo : ObservableObject
     private bool _isActive;
 
     /// <summary>
+    /// True while the row shows its inline rename box. Only one session at a
+    /// time is in this state.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isRenaming;
+
+    /// <summary>
+    /// Scratch buffer for the rename box, so cancelling leaves
+    /// <see cref="Name"/> untouched.
+    /// </summary>
+    [ObservableProperty]
+    private string _editingName = string.Empty;
+
+    /// <summary>
+    /// True once the user renamed this session by hand; mirrors
+    /// <see cref="SessionEntry.TitleIsCustom"/>.
+    /// </summary>
+    public bool HasCustomTitle { get; set; }
+
+    /// <summary>
     /// Cumulative USD cost for this session. Null until the first message is sent.
     /// </summary>
     [ObservableProperty]
@@ -131,6 +151,7 @@ public partial class SessionListViewModel : ObservableObject
             {
                 PersistedId = entry.Id,
                 Name = entry.Title,
+                HasCustomTitle = entry.TitleIsCustom,
                 LastActivity = entry.LastActivityUtc.ToLocalTime(),
                 IsActive = false
             };
@@ -169,6 +190,77 @@ public partial class SessionListViewModel : ObservableObject
         if (session is null) return;
         SelectedSession = session;
         SessionOpenRequested?.Invoke(session);
+    }
+
+    /// <summary>
+    /// Puts a row into inline rename mode. Any other row being renamed is
+    /// closed first, so only one rename box is ever open.
+    /// </summary>
+    [RelayCommand]
+    private void BeginRename(SessionInfo? session)
+    {
+        if (session is null) return;
+
+        foreach (var other in Sessions)
+        {
+            if (!ReferenceEquals(other, session))
+                other.IsRenaming = false;
+        }
+
+        session.EditingName = session.Name;
+        session.IsRenaming = true;
+    }
+
+    [RelayCommand]
+    private void CancelRename(SessionInfo? session)
+    {
+        if (session is null) return;
+        session.IsRenaming = false;
+        session.EditingName = session.Name;
+    }
+
+    /// <summary>
+    /// Applies the typed name and persists it. A blank or unchanged name is
+    /// treated as a cancel.
+    /// </summary>
+    [RelayCommand]
+    private async Task CommitRenameAsync(SessionInfo? session)
+    {
+        if (session is null || !session.IsRenaming) return;
+
+        session.IsRenaming = false;
+
+        var newName = session.EditingName?.Trim() ?? string.Empty;
+        if (newName.Length == 0 || newName == session.Name)
+        {
+            session.EditingName = session.Name;
+            return;
+        }
+
+        session.Name = newName;
+        session.HasCustomTitle = true;
+
+        // The name is part of the filter predicate, so a rename can move the
+        // row in or out of the current search results.
+        FilteredSessions.Refresh();
+
+        if (session.PersistedId.HasValue && _sessionStore is not null && _folderPath is not null)
+        {
+            try
+            {
+                var index = await _sessionStore.GetSessionIndexAsync(_folderPath);
+                var entry = index.FirstOrDefault(e => e.Id == session.PersistedId.Value);
+                if (entry is not null)
+                {
+                    // Leave LastActivityUtc alone — renaming is not activity and
+                    // must not reorder the list.
+                    entry.Title = newName;
+                    entry.TitleIsCustom = true;
+                    await _sessionStore.UpdateSessionAsync(_folderPath, entry);
+                }
+            }
+            catch { /* best effort — the new name still shows in this session */ }
+        }
     }
 
     [RelayCommand]

--- a/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml
@@ -168,6 +168,28 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+
+        <!-- WPF menus don't pick up the VS theme on their own, so the shell
+             brushes are applied by hand. -->
+        <Style x:Key="SessionMenuStyle" TargetType="ContextMenu">
+            <Setter Property="Background" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMenuBackgroundGradientKey}}" />
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarTextActiveKey}}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMenuBorderKey}}" />
+            <Setter Property="BorderThickness" Value="1" />
+        </Style>
+
+        <Style x:Key="SessionMenuItemStyle" TargetType="MenuItem">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarTextActiveKey}}" />
+            <Setter Property="Padding" Value="6,4" />
+            <Style.Triggers>
+                <Trigger Property="IsHighlighted" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMouseOverBackgroundGradientKey}}" />
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarTextHoverKey}}" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
     </UserControl.Resources>
 
     <Grid Background="{DynamicResource {x:Static vs:VsBrushes.ToolWindowBackgroundKey}}">
@@ -232,14 +254,30 @@
                          commands. -->
                     <Grid Cursor="Hand" Margin="6,4"
                           Tag="{Binding DataContext, RelativeSource={RelativeSource AncestorType=ListBox}}">
+                        <!-- One menu per row, reached by right-clicking the row
+                             or by the "..." button. The menu sits outside the
+                             visual tree, so its items go through
+                             PlacementTarget: .Tag is the list view model,
+                             .DataContext the row's session. Both the row and
+                             the button carry that Tag. -->
                         <Grid.ContextMenu>
-                            <ContextMenu>
+                            <ContextMenu Style="{StaticResource SessionMenuStyle}">
                                 <MenuItem Header="Rename"
+                                          Style="{StaticResource SessionMenuItemStyle}"
                                           Command="{Binding PlacementTarget.Tag.BeginRenameCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                    <MenuItem.Icon>
+                                        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.Rename}" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
                                 <MenuItem Header="Delete"
+                                          Style="{StaticResource SessionMenuItemStyle}"
                                           Command="{Binding PlacementTarget.Tag.RemoveSessionCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                    <MenuItem.Icon>
+                                        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.Trash}" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
                             </ContextMenu>
                         </Grid.ContextMenu>
 
@@ -269,35 +307,57 @@
                             </TextBlock>
                         </StackPanel>
 
+                        <!-- Quiet marker so a pinned row reads as pinned while
+                             the action strip is hidden. -->
+                        <imaging:CrispImage x:Name="PinIndicator"
+                                            Width="12" Height="12"
+                                            Opacity="0.7"
+                                            Visibility="Collapsed"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Margin="0,0,4,0"
+                                            Moniker="{x:Static catalog:KnownMonikers.Pin}"
+                                            IsHitTestVisible="False" />
+
                         <StackPanel x:Name="RowActions"
                                     Orientation="Horizontal"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Center"
                                     Visibility="Hidden">
-                            <Button Style="{StaticResource RowActionButtonStyle}"
-                                    ToolTip="Rename session"
-                                    Command="{Binding DataContext.BeginRenameCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                            <Button x:Name="PinButton"
+                                    Style="{StaticResource RowActionButtonStyle}"
+                                    ToolTip="Pin to top"
+                                    Command="{Binding DataContext.TogglePinCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
                                     CommandParameter="{Binding}">
-                                <imaging:CrispImage Width="16" Height="16"
-                                                    Moniker="{x:Static catalog:KnownMonikers.Rename}" />
+                                <imaging:CrispImage x:Name="PinIcon" Width="16" Height="16"
+                                                    Moniker="{x:Static catalog:KnownMonikers.Pin}" />
                             </Button>
                             <Button Style="{StaticResource RowActionButtonStyle}"
-                                    ToolTip="Delete session"
-                                    Command="{Binding DataContext.RemoveSessionCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                    CommandParameter="{Binding}">
+                                    ToolTip="More options"
+                                    Tag="{Binding DataContext, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                    Click="RowMenuButton_Click">
                                 <imaging:CrispImage Width="16" Height="16"
-                                                    Moniker="{x:Static catalog:KnownMonikers.Trash}" />
+                                                    Moniker="{x:Static catalog:KnownMonikers.Ellipsis}" />
                             </Button>
                         </StackPanel>
                     </Grid>
+                    <!-- Order matters: later triggers win where they overlap,
+                         so hover hides the pin marker and renaming hides both. -->
                     <DataTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsPinned}" Value="True">
+                            <Setter TargetName="PinIndicator" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PinIcon" Property="Moniker" Value="{x:Static catalog:KnownMonikers.Unpin}" />
+                            <Setter TargetName="PinButton" Property="ToolTip" Value="Unpin" />
+                        </DataTrigger>
                         <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
                             <Setter TargetName="RowActions" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="PinIndicator" Property="Visibility" Value="Collapsed" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding IsRenaming}" Value="True">
                             <Setter TargetName="NameText" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="RenameBox" Property="Visibility" Value="Visible" />
                             <Setter TargetName="RowActions" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PinIndicator" Property="Visibility" Value="Collapsed" />
                         </DataTrigger>
                     </DataTemplate.Triggers>
                 </DataTemplate>

--- a/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml
+++ b/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml
@@ -131,17 +131,19 @@
             </Setter>
         </Style>
 
-        <!-- Delete button: transparent pill, shown on row hover, overlaid above text -->
-        <Style x:Key="DeleteButtonStyle" TargetType="Button">
+        <!-- Row action button (rename, delete): transparent pill, shown on row
+             hover, overlaid above the text. Visibility is driven by the row
+             action strip, not by the button itself. -->
+        <Style x:Key="RowActionButtonStyle" TargetType="Button">
             <Setter Property="Background" Value="{DynamicResource {x:Static vs:VsBrushes.CommandBarMouseOverBackgroundGradientKey}}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Padding" Value="4,2" />
-            <Setter Property="Margin" Value="0" />
+            <Setter Property="Margin" Value="2,0,0,0" />
             <Setter Property="VerticalAlignment" Value="Center" />
-            <Setter Property="HorizontalAlignment" Value="Right" />
             <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Visibility" Value="Hidden" />
-            <Setter Property="ToolTip" Value="Delete session" />
+            <!-- Clicking an action selects the row; that must not also open the
+                 session window. -->
+            <EventSetter Event="PreviewMouseLeftButtonDown" Handler="RowAction_PreviewMouseLeftButtonDown" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
@@ -219,15 +221,47 @@
                  SelectedItem="{Binding SelectedSession}"
                  SelectionChanged="ListBox_SelectionChanged"
                  MouseDoubleClick="ListBox_MouseDoubleClick"
+                 PreviewMouseLeftButtonUp="ListBox_PreviewMouseLeftButtonUp"
+                 PreviewKeyDown="ListBox_PreviewKeyDown"
                  ItemContainerStyle="{StaticResource FluentListBoxItemStyle}"
                  Margin="4,0,4,4">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Grid Cursor="Hand" Margin="6,4">
+                    <!-- Tag carries the list view model so the context menu,
+                         which lives outside the visual tree, can reach its
+                         commands. -->
+                    <Grid Cursor="Hand" Margin="6,4"
+                          Tag="{Binding DataContext, RelativeSource={RelativeSource AncestorType=ListBox}}">
+                        <Grid.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Rename"
+                                          Command="{Binding PlacementTarget.Tag.BeginRenameCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                                <MenuItem Header="Delete"
+                                          Command="{Binding PlacementTarget.Tag.RemoveSessionCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
+                            </ContextMenu>
+                        </Grid.ContextMenu>
+
                         <StackPanel>
-                            <TextBlock Text="{Binding Name, Mode=OneWay}"
-                                       FontWeight="SemiBold" FontSize="13"
-                                       TextTrimming="CharacterEllipsis" />
+                            <Grid>
+                                <TextBlock x:Name="NameText"
+                                           Text="{Binding Name, Mode=OneWay}"
+                                           FontWeight="SemiBold" FontSize="13"
+                                           TextTrimming="CharacterEllipsis" />
+                                <TextBox x:Name="RenameBox"
+                                         Visibility="Collapsed"
+                                         Style="{StaticResource FluentTextBoxStyle}"
+                                         Text="{Binding EditingName, UpdateSourceTrigger=PropertyChanged}"
+                                         FontWeight="SemiBold" FontSize="13"
+                                         Padding="3,1"
+                                         Background="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBackgroundKey}}"
+                                         Foreground="{DynamicResource {x:Static vs:VsBrushes.WindowTextKey}}"
+                                         BorderBrush="{DynamicResource {x:Static vs:VsBrushes.ComboBoxBorderKey}}"
+                                         IsVisibleChanged="RenameBox_IsVisibleChanged"
+                                         KeyDown="RenameBox_KeyDown"
+                                         LostKeyboardFocus="RenameBox_LostKeyboardFocus" />
+                            </Grid>
                             <TextBlock FontSize="11" Opacity="0.7"
                                        TextTrimming="CharacterEllipsis">
                                 <Run Text="Last activity " />
@@ -235,17 +269,35 @@
                             </TextBlock>
                         </StackPanel>
 
-                        <Button x:Name="DeleteButton"
-                                Style="{StaticResource DeleteButtonStyle}"
-                                Command="{Binding DataContext.RemoveSessionCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                CommandParameter="{Binding}">
-                            <imaging:CrispImage Width="16" Height="16"
-                                                Moniker="{x:Static catalog:KnownMonikers.Trash}" />
-                        </Button>
+                        <StackPanel x:Name="RowActions"
+                                    Orientation="Horizontal"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Visibility="Hidden">
+                            <Button Style="{StaticResource RowActionButtonStyle}"
+                                    ToolTip="Rename session"
+                                    Command="{Binding DataContext.BeginRenameCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                    CommandParameter="{Binding}">
+                                <imaging:CrispImage Width="16" Height="16"
+                                                    Moniker="{x:Static catalog:KnownMonikers.Rename}" />
+                            </Button>
+                            <Button Style="{StaticResource RowActionButtonStyle}"
+                                    ToolTip="Delete session"
+                                    Command="{Binding DataContext.RemoveSessionCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                    CommandParameter="{Binding}">
+                                <imaging:CrispImage Width="16" Height="16"
+                                                    Moniker="{x:Static catalog:KnownMonikers.Trash}" />
+                            </Button>
+                        </StackPanel>
                     </Grid>
                     <DataTemplate.Triggers>
                         <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
-                            <Setter TargetName="DeleteButton" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="RowActions" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding IsRenaming}" Value="True">
+                            <Setter TargetName="NameText" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="RenameBox" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="RowActions" Property="Visibility" Value="Collapsed" />
                         </DataTrigger>
                     </DataTemplate.Triggers>
                 </DataTemplate>

--- a/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
 using VsAgentic.UI.ViewModels;
 
 namespace VsAgentic.VSExtension.ToolWindows;
@@ -8,6 +10,12 @@ namespace VsAgentic.VSExtension.ToolWindows;
 public partial class SessionListControl : UserControl
 {
     private bool _initialized;
+
+    /// <summary>
+    /// Set while a row action button (rename, delete) is being clicked, so the
+    /// selection change it causes doesn't also open the session window.
+    /// </summary>
+    private bool _suppressOpenOnSelection;
 
     public SessionListControl()
     {
@@ -52,6 +60,9 @@ public partial class SessionListControl : UserControl
 
     private void ListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        if (_suppressOpenOnSelection)
+            return;
+
         if (e.AddedItems.Count > 0
             && e.AddedItems[0] is SessionInfo session
             && DataContext is SessionListViewModel vm)
@@ -62,11 +73,95 @@ public partial class SessionListControl : UserControl
 
     private void ListBox_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
+        // A double-click inside the rename box selects a word; it must not
+        // open the session.
+        if (e.OriginalSource is DependencyObject source && FindAncestor<TextBox>(source) is not null)
+            return;
+
         // Handles re-opening a session whose window was closed while it's
         // still the selected item (SelectionChanged won't fire in that case).
         if (DataContext is SessionListViewModel vm && vm.SelectedSession is not null)
         {
             vm.OpenSessionCommand.Execute(vm.SelectedSession);
         }
+    }
+
+    private void ListBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.F2) return;
+
+        if (DataContext is SessionListViewModel vm && vm.SelectedSession is not null)
+        {
+            vm.BeginRenameCommand.Execute(vm.SelectedSession);
+            e.Handled = true;
+        }
+    }
+
+    private void ListBox_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        => _suppressOpenOnSelection = false;
+
+    private void RowAction_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        => _suppressOpenOnSelection = true;
+
+    private void RenameBox_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (sender is not TextBox box || !box.IsVisible) return;
+
+        // The box is revealed by a template trigger, so it isn't focusable yet
+        // at this point — focus it once the layout pass is done.
+        box.Dispatcher.BeginInvoke(new Action(() =>
+        {
+            box.Focus();
+            Keyboard.Focus(box);
+            box.SelectAll();
+        }), DispatcherPriority.Input);
+    }
+
+    private void RenameBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (sender is not TextBox box
+            || box.DataContext is not SessionInfo session
+            || DataContext is not SessionListViewModel vm)
+        {
+            return;
+        }
+
+        if (e.Key == Key.Enter)
+        {
+            vm.CommitRenameCommand.Execute(session);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            vm.CancelRenameCommand.Execute(session);
+            e.Handled = true;
+        }
+    }
+
+    private void RenameBox_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        // Clicking away keeps what was typed. Enter and Escape have already
+        // left rename mode, so the command is a no-op in those cases.
+        if (sender is TextBox box
+            && box.DataContext is SessionInfo session
+            && DataContext is SessionListViewModel vm)
+        {
+            vm.CommitRenameCommand.Execute(session);
+        }
+    }
+
+    private static T? FindAncestor<T>(DependencyObject start) where T : DependencyObject
+    {
+        for (DependencyObject? node = start; node is not null;)
+        {
+            if (node is T match) return match;
+
+            // Inline content (Run, Hyperlink) has no visual parent, so fall
+            // back to the logical tree for those nodes.
+            node = node is Visual or System.Windows.Media.Media3D.Visual3D
+                ? VisualTreeHelper.GetParent(node)
+                : LogicalTreeHelper.GetParent(node);
+        }
+        return null;
     }
 }

--- a/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml.cs
+++ b/src/VsAgentic.VSExtension/ToolWindows/SessionListControl.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -102,6 +103,30 @@ public partial class SessionListControl : UserControl
 
     private void RowAction_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         => _suppressOpenOnSelection = true;
+
+    private void RowMenuButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button) return;
+
+        // The row owns the menu; the button only drops it below itself, the
+        // way a "..." overflow reads elsewhere.
+        var menu = FindAncestorContextMenu(button);
+        if (menu is null) return;
+
+        menu.PlacementTarget = button;
+        menu.Placement = PlacementMode.Bottom;
+        menu.IsOpen = true;
+    }
+
+    private static ContextMenu? FindAncestorContextMenu(DependencyObject start)
+    {
+        for (DependencyObject? node = start; node is not null; node = VisualTreeHelper.GetParent(node))
+        {
+            if (node is FrameworkElement element && element.ContextMenu is not null)
+                return element.ContextMenu;
+        }
+        return null;
+    }
 
     private void RenameBox_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
     {

--- a/src/VsAgentic.VSExtension/VsAgenticPackage.cs
+++ b/src/VsAgentic.VSExtension/VsAgenticPackage.cs
@@ -325,6 +325,19 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
 
                     // Link the view model to its session entry so cost updates flow back to the list
                     viewModel.SessionInfo = session;
+                    viewModel.HasCustomTitle = session.HasCustomTitle;
+
+                    // A rename in the session list flows into the open window:
+                    // caption and generated-title suppression follow the new name.
+                    System.ComponentModel.PropertyChangedEventHandler onSessionChanged = (_, e) =>
+                    {
+                        if (e.PropertyName != nameof(SessionInfo.Name)) return;
+                        if (viewModel.SessionTitle == session.Name) return;
+
+                        viewModel.HasCustomTitle = session.HasCustomTitle;
+                        viewModel.SessionTitle = session.Name;
+                    };
+                    session.PropertyChanged += onSessionChanged;
 
                     // Sync generated title back to session list (plain title)
                     // and window caption (animated DisplayTitle with activity
@@ -352,6 +365,7 @@ public sealed class VsAgenticPackage : AsyncPackage, IVsSolutionEvents
                     chatWindow.Closed += () =>
                     {
                         _instance?._sessionWindowMap.Remove(session.Id);
+                        session.PropertyChanged -= onSessionChanged;
                         session.IsActive = false;
                         viewModel.Dispose();
                     };


### PR DESCRIPTION
﻿Fixes #38

### Change

**Rename.** Each row can be renamed in place. Enter applies the name, Escape
discards it, and clicking away applies it. A blank name is treated as a cancel.
The edit box is opened from the `...` menu, from the row's context menu, or with
F2 on the selected row.

The name is written to `SessionEntry.Title` together with a new
`TitleIsCustom` flag. `ChatSessionViewModel` skips the generated title when that
flag is set, including the case where the user renames the session while the
title is still being generated. Renaming an open session updates the tool window
caption, and it leaves `LastActivityUtc` alone so the list keeps its order.

**Pin.** A pin toggle holds a session above the sessions sorted by activity, and
`SessionEntry.IsPinned` keeps it there across a restart. A pinned row shows a
small pin marker when it is not hovered. The reorder is a stable partition, so
pinning moves one row and leaves the rest of the list as it was. A new session is
inserted below the pinned rows rather than at the top.

<img width="1282" height="384" alt="image" src="https://github.com/user-attachments/assets/f7b5126b-410b-4c0a-8d53-44ba1f307ada" />

**Row actions.** The rename and delete icons are replaced by a pin toggle and a
`...` button. The menu behind that button holds Rename and Delete, and the same
menu opens on right-click anywhere in the row. Each row owns its own menu
instance. The menu is styled with shell brushes, because a WPF menu in a tool
window otherwise renders in the default light style in a dark theme.

<img width="1656" height="372" alt="image" src="https://github.com/user-attachments/assets/fc9078d5-1582-4f8d-9a06-dda22e48e714" />

Clicking a row action no longer opens the session window. The click selects the
row, and the selection change used to trigger `OpenSession`.

### Trade-off worth naming

Rename and pin are in one PR because they share the `...` menu and the same four
files. Splitting them would mean building that menu twice and resolving a
conflict between the two branches. If you would rather review them apart, I can
split the branch.

### Not included

No keyboard shortcut for pin, no manual ordering inside the pinned group, and no
archive. Sessions are still sorted by last activity within each group.

### Verified

Built and run in the experimental instance: rename from the menu and with F2,
Escape and click-away, a hand-typed title surviving the first message and a
restart, pinning and unpinning, and the pinned order after a restart.

No version bump included, same as the other PRs.
